### PR TITLE
fix: remove `shallowCompare` in `shouldComponentUpdate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ npm install --save react-native-tab-view react-addons-shallow-compare
 
 ```js
 import React, { Component } from 'react';
+import shallowCompare from 'react-addons-shallow-compare';
 import { View, StyleSheet } from 'react-native';
 import { TabViewAnimated, TabViewPage, TabBarTop } from 'react-native-tab-view';
 
@@ -49,6 +50,10 @@ export default class TabViewExample extends Component {
       { key: '2', title: 'Second' },
     ],
   };
+
+  shouldComponentUpdate(nextProps: Props, nextState: void) {
+    return shallowCompare(this, nextProps, nextState);
+  }
 
   _handleChangeTab = (index) => {
     this.setState({ index });
@@ -144,36 +149,6 @@ It accepts the following props in addition to the props accepted by `<TabBar />`
 
 
 Check the [type definitions](src/TabViewTypeDefinitions.js) for details on shape of different objects.
-
-
-## Caveats
-
-`<TabViewAnimated />` and `<TabViewTransitioner />` implement `shouldComponentUpdate` to prevent unnecessary re-rendering. As a side-effect, the tabs won't re-render if something changes in the parent's state. If you need it to trigger a re-render, put it in the `navigationState`.
-
-For example, consider you have a `loaded` property on state which should trigger re-render. You can have your state like the following -
-
-```js
-state = {
-  index: 0,
-  routes: [
-    { key: '1', title: 'First' },
-    { key: '2', title: 'Second' },
-  ],
-  loaded: false,
-}
-```
-
-Then just pass `this.state` as the `navigationState` prop to `<TabViewAnimated />` or `<TabViewTransitioner />`.
-
-
-```js
-<TabViewAnimated
-  navigationState={this.state}
-  renderScene={this._renderPage}
-  renderHeader={this._renderHeader}
-  onRequestChangeTab={this._handleChangeTab}
-/>
-```
 
 
 ## Optimization Tips

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*",
-    "react-addons-shallow-compare": "*"
+    "react-native": "*"
   }
 }

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -7,7 +7,6 @@ import {
   View,
   Text,
 } from 'react-native';
-import shallowCompare from 'react-addons-shallow-compare';
 import TouchableItem from './TouchableItem';
 import { SceneRendererPropType } from './TabViewPropTypes';
 import type { Scene, SceneRendererProps } from './TabViewTypeDefinitions';
@@ -62,10 +61,6 @@ export default class TabBar extends Component<DefaultProps, Props, void> {
   static defaultProps = {
     renderLabel: ({ route }) => route.title ? <Text style={styles.tablabel}>{route.title}</Text> : null,
   };
-
-  shouldComponentUpdate(nextProps: Props, nextState: void) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     const { position } = this.props;

--- a/src/TabBarTop.js
+++ b/src/TabBarTop.js
@@ -7,7 +7,6 @@ import {
   Text,
   View,
 } from 'react-native';
-import shallowCompare from 'react-addons-shallow-compare';
 import TabBar from './TabBar';
 import { SceneRendererPropType } from './TabViewPropTypes';
 import type { Scene, SceneRendererProps } from './TabViewTypeDefinitions';
@@ -40,10 +39,6 @@ export default class TabBarTop extends Component<void, Props, void> {
     indicatorStyle: View.propTypes.style,
     labelStyle: Text.propTypes.style,
   };
-
-  shouldComponentUpdate(nextProps: Props, nextState: void) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   _renderLabel = ({ route }: Scene) => (
     route.title ? <Text style={[ styles.tabLabel, this.props.labelStyle ]}>{route.title.toUpperCase()}</Text> : null

--- a/src/TabViewAnimated.js
+++ b/src/TabViewAnimated.js
@@ -5,7 +5,6 @@ import {
   View,
   StyleSheet,
 } from 'react-native';
-import shallowCompare from 'react-addons-shallow-compare';
 import TabViewTransitioner from './TabViewTransitioner';
 import { NavigationStatePropType } from './TabViewPropTypes';
 import type { NavigationState, Route, SceneRendererProps } from './TabViewTypeDefinitions';
@@ -51,10 +50,6 @@ export default class TabViewAnimated extends Component<void, Props, State> {
   }
 
   state: State;
-
-  shouldComponentUpdate(nextProps: Props, nextState: State) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   _renderScene = (props: SceneRendererProps & { route: Route }) => {
     const { renderScene, navigationState, lazy } = this.props;

--- a/src/TabViewPage.js
+++ b/src/TabViewPage.js
@@ -7,7 +7,6 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
-import shallowCompare from 'react-addons-shallow-compare';
 import TabViewPanResponder from './TabViewPanResponder';
 import TabViewStyleInterpolator from './TabViewStyleInterpolator';
 import { SceneRendererPropType } from './TabViewPropTypes';
@@ -83,10 +82,6 @@ export default class TabViewPage extends Component<void, Props, void> {
 
   componentWillReceiveProps(nextProps: Props) {
     this._setPanHandlers(nextProps);
-  }
-
-  shouldComponentUpdate(nextProps: Props, nextState: void) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   _setPanHandlers = (props: Props) => {

--- a/src/TabViewTransitioner.js
+++ b/src/TabViewTransitioner.js
@@ -5,7 +5,6 @@ import {
   Animated,
   View,
 } from 'react-native';
-import shallowCompare from 'react-addons-shallow-compare';
 import { NavigationStatePropType } from './TabViewPropTypes';
 import type { NavigationState, SceneRendererProps } from './TabViewTypeDefinitions';
 
@@ -72,10 +71,6 @@ export default class TabViewTransitioner extends Component<DefaultProps, Props, 
 
   componentDidMount() {
     this._positionListener = this.state.position.addListener(this._trackPosition);
-  }
-
-  shouldComponentUpdate(nextProps: Props, nextState: State) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
Having `shouldComponentUpdate` implemented inside the library has proved to be more confusing than helpful. We still need to ensure minimal updates to have performant animations and gestures. So we recommend users to implement `shouldComponentUpdate` and have it in the README. We do minimal `setState` inside the library, so there should be no unnecessary rendering caused by the library code, but users code.