### PR TITLE
feat: add a shouldOptimizeUpdates prop to customize shouldComponentUpdate behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ It accepts the following props,
 - `configureAnimation` - optional callback which performs animation and returns a promise
 - `onRequestChangeTab` - callback for when the current tab changes, should do the `setState`
 - `onChangePosition` - callback called with position value as it changes (e.g. - on swipe or tab change), avoid doing anything expensive here
+- `shouldOptimizeUpdates` - whether to implement a `shouldComponentUpdate` strategy to minimize updates, enabled by default
 - `render` - callback which renders the tab view, gets a special set of props as argument
 
 ### `<TabViewAnimated />`

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -7,7 +7,6 @@ import {
   View,
   Text,
 } from 'react-native';
-import shallowCompare from 'react-addons-shallow-compare';
 import TouchableItem from './TouchableItem';
 import { SceneRendererPropType } from './TabViewPropTypes';
 import type { Scene, SceneRendererProps } from './TabViewTypeDefinitions';
@@ -62,10 +61,6 @@ export default class TabBar extends Component<DefaultProps, Props, void> {
   static defaultProps = {
     renderLabel: ({ route }) => route.title ? <Text style={styles.tablabel}>{route.title}</Text> : null,
   };
-
-  shouldComponentUpdate(nextProps: Props, nextState: void) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   render() {
     const { position } = this.props;

--- a/src/TabBarTop.js
+++ b/src/TabBarTop.js
@@ -7,7 +7,6 @@ import {
   Text,
   View,
 } from 'react-native';
-import shallowCompare from 'react-addons-shallow-compare';
 import TabBar from './TabBar';
 import { SceneRendererPropType } from './TabViewPropTypes';
 import type { Scene, SceneRendererProps } from './TabViewTypeDefinitions';
@@ -40,10 +39,6 @@ export default class TabBarTop extends Component<void, Props, void> {
     indicatorStyle: View.propTypes.style,
     labelStyle: Text.propTypes.style,
   };
-
-  shouldComponentUpdate(nextProps: Props, nextState: void) {
-    return shallowCompare(this, nextProps, nextState);
-  }
 
   _renderLabel = ({ route }: Scene) => (
     route.title ? <Text style={[ styles.tabLabel, this.props.labelStyle ]}>{route.title.toUpperCase()}</Text> : null

--- a/src/TabViewAnimated.js
+++ b/src/TabViewAnimated.js
@@ -23,6 +23,7 @@ type Props = {
   renderHeader?: () => ?React.Element<any>;
   renderFooter?: () => ?React.Element<any>;
   onChangePosition?: (value: number) => void;
+  shouldOptimizeUpdates: boolean;
   lazy?: boolean;
   style?: any;
 }
@@ -38,6 +39,7 @@ export default class TabViewAnimated extends Component<void, Props, State> {
     renderHeader: PropTypes.func,
     renderFooter: PropTypes.func,
     onChangePosition: PropTypes.func,
+    shouldOptimizeUpdates: PropTypes.bool,
     lazy: PropTypes.bool,
     style: View.propTypes.style,
   };
@@ -53,7 +55,11 @@ export default class TabViewAnimated extends Component<void, Props, State> {
   state: State;
 
   shouldComponentUpdate(nextProps: Props, nextState: State) {
-    return shallowCompare(this, nextProps, nextState);
+    if (this.props.shouldOptimizeUpdates === false) {
+      return true;
+    } else {
+      return shallowCompare(this, nextProps, nextState);
+    }
   }
 
   _renderScene = (props: SceneRendererProps & { route: Route }) => {

--- a/src/TabViewPage.js
+++ b/src/TabViewPage.js
@@ -7,7 +7,6 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
-import shallowCompare from 'react-addons-shallow-compare';
 import TabViewPanResponder from './TabViewPanResponder';
 import TabViewStyleInterpolator from './TabViewStyleInterpolator';
 import { SceneRendererPropType } from './TabViewPropTypes';
@@ -83,10 +82,6 @@ export default class TabViewPage extends Component<void, Props, void> {
 
   componentWillReceiveProps(nextProps: Props) {
     this._setPanHandlers(nextProps);
-  }
-
-  shouldComponentUpdate(nextProps: Props, nextState: void) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   _setPanHandlers = (props: Props) => {

--- a/src/TabViewTransitioner.js
+++ b/src/TabViewTransitioner.js
@@ -21,6 +21,7 @@ type Props = {
   configureAnimation: Animator;
   onRequestChangeTab: (index: number) => void;
   onChangePosition: (value: number) => void;
+  shouldOptimizeUpdates: boolean;
   style?: any;
 }
 
@@ -40,6 +41,7 @@ export default class TabViewTransitioner extends Component<DefaultProps, Props, 
     configureAnimation: PropTypes.func.isRequired,
     onRequestChangeTab: PropTypes.func.isRequired,
     onChangePosition: PropTypes.func,
+    shouldOptimizeUpdates: PropTypes.bool,
     style: View.propTypes.style,
   };
 
@@ -75,7 +77,11 @@ export default class TabViewTransitioner extends Component<DefaultProps, Props, 
   }
 
   shouldComponentUpdate(nextProps: Props, nextState: State) {
-    return shallowCompare(this, nextProps, nextState);
+    if (this.props.shouldOptimizeUpdates === false) {
+      return true;
+    } else {
+      return shallowCompare(this, nextProps, nextState);
+    }
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
I removed `shouldComponentUpdate` from all components other than `TabViewAnimated` and `TabViewTransitioner` since they are rendered by `TabViewTransitioner`, hence the extra `shouldComponentUpdate` is not necessary.

cc @skevy @knowbody 