### PR TITLE
fix: optional callback for _transitionTo

### DIFF
--- a/src/TabViewTransitioner.js
+++ b/src/TabViewTransitioner.js
@@ -142,7 +142,7 @@ export default class TabViewTransitioner extends Component<DefaultProps, Props, 
     };
   }
 
-  _transitionTo = (toValue: number, callback: Function) => {
+  _transitionTo = (toValue: number, callback?: Function) => {
     const lastPosition = this._getLastPosition();
     if (lastPosition === toValue) {
       return;


### PR DESCRIPTION
Attempting to add flow to my project, and encountered this:
```
node_modules/react-native-tab-view/src/TabViewTransitioner.js:94
 94:     this._transitionTo(this.props.navigationState.index);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call of method `_transitionTo`
 94:     this._transitionTo(this.props.navigationState.index);
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ undefined (too few arguments, expected default/rest parameters). This type is incompatible with
145:   _transitionTo = (toValue: number, callback: Function) => {
                                                   ^^^^^^^^ function type
```