### PR TITLE
cleanup: remove unused Animated import

### DIFF
--- a/src/TabViewPanResponder.js
+++ b/src/TabViewPanResponder.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { Animated, Platform } from 'react-native';
+import { Platform } from 'react-native';
 import type { GestureEvent, GestureState } from './PanResponderTypes';
 import type { Route, SceneRendererProps } from './TabViewTypeDefinitions';
 


### PR DESCRIPTION
eslint spits out:
```
/home/wli/projects/react-native-tab-view/src/TabViewPanResponder.js
  3:10  error  'Animated' is defined but never used  no-unused-vars
```
