### PR TITLE
Only update layout state if it changed

### DIFF
--- a/src/TabViewTransitioner.js
+++ b/src/TabViewTransitioner.js
@@ -123,6 +123,10 @@ export default class TabViewTransitioner extends Component<DefaultProps, Props, 
   _handleLayout = (e: any) => {
     const { height, width } = e.nativeEvent.layout;
 
+    if (this.state.layout.width === width && this.state.layout.height === height) {
+      return;
+    }
+
     this.setState({
       layout: {
         measured: true,


### PR DESCRIPTION
I just upgraded my app to React Native 0.34 and I have a react-native-maps `MapView` in one of my tabs.

I noticed that the map was continuously rendering and pinned it down to the `TabViewTransitioner#_handleLayout()`. It calls `setState()` even if the width and height haven't changed so this patch stops that.

There was actually a recent RN commit for `NavigationTransitioner` that does the same thing here: https://github.com/facebook/react-native/commit/dadfe40f55f0fc21e833e36ac2ad67ec4160af25