### PR TITLE
Added a 'deadzone' before PanResponder capture.

### DIFF
--- a/src/TabViewPanResponder.js
+++ b/src/TabViewPanResponder.js
@@ -10,6 +10,7 @@ type Props = SceneRendererProps & {
 }
 
 const DEAD_ZONE = 20;
+
 function forHorizontal(props: Props) {
   let { swipeVelocityThreshold } = props;
 

--- a/src/TabViewPanResponder.js
+++ b/src/TabViewPanResponder.js
@@ -48,8 +48,8 @@ function forHorizontal(props: Props) {
     const { routes, index } = props.navigationState;
     return (
       isMovingHorzontally(evt, gestureState) && (
-        (gestureState.dx >= 30 && index >= 0) ||
-        (gestureState.dx <= -30 && index <= routes.length - 1)
+        (gestureState.dx >= 20 && index >= 0) ||
+        (gestureState.dx <= -20 && index <= routes.length - 1)
     ));
   }
 

--- a/src/TabViewPanResponder.js
+++ b/src/TabViewPanResponder.js
@@ -20,6 +20,7 @@ function forHorizontal(props: Props) {
 
   let lastValue = null;
   let isMoving = null;
+  let deadzone = 20;
 
   function isIndexInRange(index: number) {
     const { routes } = props.navigationState;
@@ -48,8 +49,8 @@ function forHorizontal(props: Props) {
     const { routes, index } = props.navigationState;
     return (
       isMovingHorzontally(evt, gestureState) && (
-        (gestureState.dx >= 20 && index >= 0) ||
-        (gestureState.dx <= -20 && index <= routes.length - 1)
+        (gestureState.dx >= deadzone && index >= 0) ||
+        (gestureState.dx <= -deadzone && index <= routes.length - 1)
     ));
   }
 

--- a/src/TabViewPanResponder.js
+++ b/src/TabViewPanResponder.js
@@ -20,7 +20,6 @@ function forHorizontal(props: Props) {
 
   let lastValue = null;
   let isMoving = null;
-  let deadzone = 20;
 
   function isIndexInRange(index: number) {
     const { routes } = props.navigationState;
@@ -47,10 +46,11 @@ function forHorizontal(props: Props) {
 
   function canMoveScreen(evt: GestureEvent, gestureState: GestureState) {
     const { routes, index } = props.navigationState;
+    const DEAD_ZONE = 20;
     return (
       isMovingHorzontally(evt, gestureState) && (
-        (gestureState.dx >= deadzone && index >= 0) ||
-        (gestureState.dx <= -deadzone && index <= routes.length - 1)
+        (gestureState.dx >= DEAD_ZONE && index >= 0) ||
+        (gestureState.dx <= -DEAD_ZONE && index <= routes.length - 1)
     ));
   }
 

--- a/src/TabViewPanResponder.js
+++ b/src/TabViewPanResponder.js
@@ -48,8 +48,8 @@ function forHorizontal(props: Props) {
     const { routes, index } = props.navigationState;
     return (
       isMovingHorzontally(evt, gestureState) && (
-        (gestureState.dx >= 0 && index >= 0) ||
-        (gestureState.dx <= 0 && index <= routes.length - 1)
+        (gestureState.dx >= 30 && index >= 0) ||
+        (gestureState.dx <= -30 && index <= routes.length - 1)
     ));
   }
 

--- a/src/TabViewPanResponder.js
+++ b/src/TabViewPanResponder.js
@@ -9,6 +9,7 @@ type Props = SceneRendererProps & {
   swipeVelocityThreshold: number;
 }
 
+const DEAD_ZONE = 20;
 function forHorizontal(props: Props) {
   let { swipeVelocityThreshold } = props;
 
@@ -46,7 +47,6 @@ function forHorizontal(props: Props) {
 
   function canMoveScreen(evt: GestureEvent, gestureState: GestureState) {
     const { routes, index } = props.navigationState;
-    const DEAD_ZONE = 20;
     return (
       isMovingHorzontally(evt, gestureState) && (
         (gestureState.dx >= DEAD_ZONE && index >= 0) ||


### PR DESCRIPTION
After playing with this library on a few different devices (iOS and Android) it became apparent that the capture point for horizontal scrolling is too sensitive.

This is even more noticeable on phones like the Galaxy S7 and S7 Edge where it became almost impossible to tap on buttons as the swipe capture would take over onTapStart.

This pull adds a `-20 => 20`pt deadzone before capture begins - in other words, when dragging the motion needs to traverse more than 20pt before the PanResponder becomes responder. Might want to make this configurable via component props - although probably not necessary.

For normal swiping the deadzone isn't noticeable while allowing for more natural UI interaction.