### PR TITLE
Use Animated.View for TabBar root container

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -104,7 +104,7 @@ export default class TabBar extends Component<DefaultProps, Props, State> {
     onTabPress: PropTypes.func,
     tabWidth: PropTypes.number,
     tabStyle: View.propTypes.style,
-    style: View.propTypes.style,
+    style: Animated.View.propTypes.style,
   };
 
   static defaultProps = {

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -272,7 +272,7 @@ export default class TabBar extends Component<DefaultProps, Props, State> {
     });
 
     return (
-      <View style={[ styles.tabbar, this.props.style ]}>
+      <Animated.View style={[ styles.tabbar, this.props.style ]}>
         <Animated.View pointerEvents='none' style={[ styles.indiator, scrollEnabled ? { width: tabBarWidth, transform: [ { translateX } ] } : null ]}>
           {this.props.renderIndicator ?
             this.props.renderIndicator({
@@ -357,7 +357,7 @@ export default class TabBar extends Component<DefaultProps, Props, State> {
             );
           })}
         </ScrollView>
-      </View>
+      </Animated.View>
     );
   }
 }


### PR DESCRIPTION
This PR simply replaces the root container of the `TabBar` component from `View` to `Animated.View`. 
This way, properties like `backgroundColor` can be dynamically animated based on the active tab.

I don't think there are any side effects to doing this, but let me know if I'm missing something. 

Cheers!