### PR TITLE
Add "accessible" and "accessibilityLabel" props into <TouchableItem />

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -438,9 +438,11 @@ export default class TabBar extends PureComponent<DefaultProps, Props, State> {
 
               return (
                 <TouchableItem
+                  accessible
                   borderless
                   key={route.key}
                   accessibilityTraits='button'
+                  accessibilityLabel={route.testID}
                   testID={route.testID}
                   pressColor={this.props.pressColor}
                   pressOpacity={this.props.pressOpacity}


### PR DESCRIPTION
Hi, guys!

This PR brings ability to use accessibilityLabel on Android while E2E-testing