### PR TITLE
Maintain backward compatibility  for react native 0.39

### DIFF
--- a/src/TabViewPagerScroll.js
+++ b/src/TabViewPagerScroll.js
@@ -130,7 +130,7 @@ export default class TabViewPagerScroll extends PureComponent<void, Props, void>
         pagingEnabled
         directionalLockEnabled
         keyboardDismissMode='on-drag'
-        keyboardShouldPersistTaps={keyboardShouldPersistTapsType}
+        keyboardShouldPersistTaps={keyboardShouldPersistTapsType || true}
         scrollEnabled={this.props.swipeEnabled}
         automaticallyAdjustContentInsets={false}
         bounces={false}

--- a/src/TabViewPagerScroll.js
+++ b/src/TabViewPagerScroll.js
@@ -123,14 +123,14 @@ export default class TabViewPagerScroll extends PureComponent<void, Props, void>
   _setRef = (el: Object) => (this._scrollView = el);
 
   render() {
-    const { children, layout, navigationState } = this.props;
+    const { children, layout, navigationState, keyboardShouldPersistTapsType } = this.props;
     return (
       <ScrollView
         horizontal
         pagingEnabled
         directionalLockEnabled
         keyboardDismissMode='on-drag'
-        keyboardShouldPersistTaps='always'
+        keyboardShouldPersistTaps={keyboardShouldPersistTapsType}
         scrollEnabled={this.props.swipeEnabled}
         automaticallyAdjustContentInsets={false}
         bounces={false}
@@ -157,14 +157,14 @@ export default class TabViewPagerScroll extends PureComponent<void, Props, void>
             {child}
           </View>
         )) : (
-          <View
-            key={navigationState.routes[navigationState.index].key}
-            testID={navigationState.routes[navigationState.index].testID}
-            style={styles.page}
-          >
-            {Children.toArray(children)[navigationState.index]}
-          </View>
-        )}
+            <View
+              key={navigationState.routes[navigationState.index].key}
+              testID={navigationState.routes[navigationState.index].testID}
+              style={styles.page}
+            >
+              {Children.toArray(children)[navigationState.index]}
+            </View>
+          )}
       </ScrollView>
     );
   }

--- a/src/TabViewTypeDefinitions.js
+++ b/src/TabViewTypeDefinitions.js
@@ -30,6 +30,7 @@ export type SceneRendererProps = {
   layout: Layout & {
     measured: boolean;
   };
+  keyboardShouldPersistTapsType: string;
   navigationState: NavigationState;
   position: Animated.Value;
   jumpToIndex: (index: number) => void;


### PR DESCRIPTION
Into the TabViewPagerScroll component we have a property keyboardShouldPersistTaps wich take a boolean property in react native 0.39 and not a string look like react native 0.4x.

I have add a new property for configure this property if we need it to change and fallback value 