### PR TITLE
Update accessible and accessibilityLabel fields

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -428,13 +428,15 @@ export default class TabBar extends PureComponent<DefaultProps, Props, State> {
                 tabContainerStyle.flex = 1;
               }
 
+              const accessibilityLabel = route.accessibilityLabel || route.title;
+
               return (
                 <TouchableItem
-                  accessible
                   borderless
                   key={route.key}
                   testID={route.testID}
-                  accessibilityLabel={route.title}
+                  accessible={route.accessible}
+                  accessibilityLabel={accessibilityLabel}
                   accessibilityTraits='button'
                   pressColor={this.props.pressColor}
                   pressOpacity={this.props.pressOpacity}


### PR DESCRIPTION
Hi @satya164, it's me, again. I want to discuss one more time and suggest solution for two attributes: `accessible` and `accessibilityLabel`.

May be you know, that all `Touchable…` components with attribute `accessible="true"` make content inside inaccessible. I want to fix this behaviour and let the user define this attribute.

Also for `accessibilityLabel` common case — set both `testID` and `accessibilityLabel` only one value.

In my team we are using the next helper for `accessibilityLabel`s and `testID`s:
```js
import { Platform } from 'react-native'
  
export default function testID(id) {
  return Platform.OS === 'android' ?
    { accessible: true, accessibilityLabel: id } :
    { testID: id }
}
```

And how we use it:
```js
<TouchableHighlight
  style={[styles.button, this.props.isLoading && styles.buttonDisabled]}
  onPress={this.handleOnSubmit}
  underlayColor="transparent"
  {...testID('submitButton')}>
  <RobotoText style={styles.buttonText}>Log In</RobotoText>
</TouchableHighlight>
```

I hope, someone will find it helpful :)

It would be nice for me and my teammates if you merge this PR. Looks like it more convenient way to define ids for e2e-tests.

// cc @itsmepetrov