### PR TITLE
Guard scrollTo call so that Jest completes

### DIFF
--- a/src/TabViewPagerScroll.js
+++ b/src/TabViewPagerScroll.js
@@ -64,7 +64,7 @@ export default class TabViewPagerScroll extends PureComponent<void, Props, void>
   _isMomentumScroll: boolean = false;
 
   _scrollTo = (x: number) => {
-    if (this._scrollView) {
+    if (this._scrollView && this._scrollView.scrollTo) {
       this._scrollView.scrollTo({
         x,
         animated: false,


### PR DESCRIPTION
When testing with Jest in my project I get `TypeError: _this._scrollView.scrollTo is not a function`. Add this simple condition makes all my tests pass. If there's a better way to fix this that would be appreciated!