### PR TITLE
Add `containerStyle` prop to TabViewAnimated

### DIFF
--- a/src/TabViewAnimated.js
+++ b/src/TabViewAnimated.js
@@ -28,6 +28,7 @@ type Props = TransitionerProps & {
   renderHeader?: (props: SceneRendererProps) => ?React.Element<*>;
   renderFooter?: (props: SceneRendererProps) => ?React.Element<*>;
   lazy?: boolean;
+  containerStyle?: any;
 }
 
 type State = {
@@ -57,6 +58,7 @@ export default class TabViewAnimated extends PureComponent<DefaultProps, Props, 
     renderFooter: PropTypes.func,
     onChangePosition: PropTypes.func,
     lazy: PropTypes.bool,
+    containerStyle: View.propTypes.style,
   };
 
   static defaultProps = {
@@ -86,11 +88,11 @@ export default class TabViewAnimated extends PureComponent<DefaultProps, Props, 
   };
 
   _renderItems = (props: SceneRendererProps) => {
-    const { renderPager, renderHeader, renderFooter } = this.props;
+    const { renderPager, renderHeader, renderFooter, containerStyle } = this.props;
     const { navigationState } = props;
 
     return (
-      <View style={styles.container}>
+      <View style={[ styles.container, containerStyle ]}>
         {renderHeader && renderHeader(props)}
         {renderPager({
           ...props,


### PR DESCRIPTION
First off, thank you for this project, it's great!

I've run into this issue with having to overwrite the default `styles.container` style that is used in `TabViewAnimated`'s `_renderItems()` function. I am using it as a carousel that's inline with other content, and does not need to be full height. I can pass a height to the component, but in my case, I'd rather have the content dictate the height and pass `{ flexGrow: 0 }`.

Would love some feedback!