### PR TITLE
keyboardShouldPersistTaps rn 0.38 bool, and swipeEnabled prop support

### DIFF
--- a/src/TabViewPagerScroll.js
+++ b/src/TabViewPagerScroll.js
@@ -137,7 +137,7 @@ export default class TabViewPagerScroll
         pagingEnabled
         directionalLockEnabled
         keyboardDismissMode="on-drag"
-        keyboardShouldPersistTaps="always"
+        keyboardShouldPersistTaps="true"
         scrollEnabled={this.props.swipeEnabled}
         automaticallyAdjustContentInsets={false}
         bounces={false}

--- a/src/TabViewTransitioner.js
+++ b/src/TabViewTransitioner.js
@@ -48,6 +48,7 @@ export default class TabViewTransitioner
       width: PropTypes.number.isRequired,
     }),
     canJumpToTab: PropTypes.func,
+    swipeEnabled: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -135,6 +136,7 @@ export default class TabViewTransitioner
     return {
       layout: this.state.layout,
       navigationState: this.props.navigationState,
+      swipeEnabled: this.props.swipeEnabled,
       position: this.state.position,
       jumpToIndex: this._jumpToIndex,
       getLastPosition: this._getLastPosition,


### PR DESCRIPTION


rn 0.36 requires keyboardShouldPersistTaps to be boolean,
also
swipeEnabled prop was not passed to native tabview from TabViewTransitioner