### PR TITLE
Remove all references to View.propTypes

### DIFF
--- a/example/src/BottomBarIconTextExample.js
+++ b/example/src/BottomBarIconTextExample.js
@@ -20,10 +20,6 @@ export default class TopBarIconExample extends PureComponent<void, *, State> {
   static title = 'Bottom bar with indicator';
   static appbarElevation = 4;
 
-  static propTypes = {
-    style: View.propTypes.style,
-  };
-
   state: State = {
     index: 0,
     routes: [

--- a/example/src/CoverflowExample.js
+++ b/example/src/CoverflowExample.js
@@ -40,10 +40,6 @@ export default class CoverflowExample extends PureComponent<void, *, State> {
   static title = 'Coverflow';
   static appbarElevation = 0;
 
-  static propTypes = {
-    style: View.propTypes.style,
-  };
-
   state: State = {
     index: 2,
     routes: Object.keys(ALBUMS).map(key => ({ key })),

--- a/example/src/NoAnimationExample.js
+++ b/example/src/NoAnimationExample.js
@@ -29,10 +29,6 @@ export default class TopBarIconExample extends PureComponent<void, *, State> {
   static tintColor = '#222';
   static appbarElevation = 4;
 
-  static propTypes = {
-    style: View.propTypes.style,
-  };
-
   state: State = {
     index: 0,
     routes: [

--- a/example/src/ScrollViewsExample.js
+++ b/example/src/ScrollViewsExample.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React, { PureComponent } from 'react';
-import { Animated, View, StyleSheet } from 'react-native';
+import { Animated, StyleSheet } from 'react-native';
 import { TabViewAnimated, TabBar } from 'react-native-tab-view';
 import BasicListView from './BasicListView';
 
@@ -19,10 +19,6 @@ export default class TopBarTextExample extends PureComponent<void, *, State> {
   static backgroundColor = '#fff';
   static tintColor = '#222';
   static appbarElevation = 0;
-
-  static propTypes = {
-    style: View.propTypes.style,
-  };
 
   state: State = {
     index: 0,

--- a/example/src/TopBarIconExample.js
+++ b/example/src/TopBarIconExample.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React, { PureComponent } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { TabViewAnimated, TabBar } from 'react-native-tab-view';
 import SimplePage from './SimplePage';
@@ -18,10 +18,6 @@ type State = NavigationState<Route>;
 export default class TopBarIconExample extends PureComponent<void, *, State> {
   static title = 'Icon only top bar';
   static appbarElevation = 0;
-
-  static propTypes = {
-    style: View.propTypes.style,
-  };
 
   state: State = {
     index: 0,

--- a/example/src/TopBarTextExample.js
+++ b/example/src/TopBarTextExample.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React, { PureComponent } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { TabViewAnimated, TabBar } from 'react-native-tab-view';
 import SimplePage from './SimplePage';
 
@@ -17,10 +17,6 @@ type State = NavigationState<Route>;
 export default class TopBarTextExample extends PureComponent<void, *, State> {
   static title = 'Scrollable top bar';
   static appbarElevation = 0;
-
-  static propTypes = {
-    style: View.propTypes.style,
-  };
 
   state: State = {
     index: 1,

--- a/src/TabViewAnimated.js
+++ b/src/TabViewAnimated.js
@@ -75,7 +75,6 @@ export default class TabViewAnimated<T: Route<*>>
     renderHeader: PropTypes.func,
     renderFooter: PropTypes.func,
     lazy: PropTypes.bool,
-    style: View.propTypes.style,
   };
 
   static defaultProps = {

--- a/src/TouchableItem.js
+++ b/src/TouchableItem.js
@@ -46,9 +46,8 @@ export default class TouchableItem
   };
 
   render() {
-    /* eslint-disable react/prop-types */
+    // eslint-disable-next-line react/prop-types
     const { style, pressOpacity, pressColor, borderless, ...rest } = this.props;
-    /* eslint-enable react/prop-types */
 
     if (Platform.OS === 'android' && Platform.Version >= LOLLIPOP) {
       return (

--- a/src/TouchableItem.js
+++ b/src/TouchableItem.js
@@ -46,7 +46,9 @@ export default class TouchableItem
   };
 
   render() {
+    /* eslint-disable react/prop-types */
     const { style, pressOpacity, pressColor, borderless, ...rest } = this.props;
+    /* eslint-enable react/prop-types */
 
     if (Platform.OS === 'android' && Platform.Version >= LOLLIPOP) {
       return (

--- a/src/TouchableItem.js
+++ b/src/TouchableItem.js
@@ -35,7 +35,6 @@ export default class TouchableItem
     pressColor: PropTypes.string,
     pressOpacity: PropTypes.number,
     children: PropTypes.node.isRequired,
-    style: View.propTypes.style,
   };
 
   static defaultProps = {


### PR DESCRIPTION
Follow-up to #230: for compatibility with both RN 0.44.0 as well as earlier versions, we decided there to just omit all of these PropTypes.

Besides just removing these PropTypes, here is an alternate approach we can take here to preserve compatibility across RN versions:

```javascript
import {
  View,
  ViewPropTypes,
} from 'react-native';
...
tabStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
```
The destructuring import assigns undefined if the requested module does not exist in the specified file. Meanwhile, Flow is crippled on 0.43.4 by the problem [this commit fixed](https://github.com/facebook/react-native/commit/c7387fefc85fd15dceadfa291857099ed3e848b8), so it doesn't complain about the misnamed import. I've tested this on RN 0.43.4, RN 0.44.0, and master.