### PR TITLE
Add high zIndex to focused child in TabView's

### DIFF
--- a/src/TabViewPagerPan.js
+++ b/src/TabViewPagerPan.js
@@ -281,19 +281,21 @@ export default class TabViewPagerPan<T: Route<*>>
         ]}
         {...this._panResponder.panHandlers}
       >
-        {Children.map(children, (child, i) => (
-          <View
-            key={navigationState.routes[i].key}
-            testID={navigationState.routes[i].testID}
-            style={
-              width
-                ? { width }
-                : i === navigationState.index ? StyleSheet.absoluteFill : null
-            }
-          >
-            {i === navigationState.index || width ? child : null}
-          </View>
-        ))}
+        {Children.map(children, (child, i) => {
+          const isFocused = i === navigationState.index;
+          return (
+            <View
+              key={navigationState.routes[i].key}
+              testID={navigationState.routes[i].testID}
+              style={[
+                width ? { width } : isFocused ? StyleSheet.absoluteFill : null,
+                { zIndex: isFocused ? 1000 : 0 }, // set zIndex to a high number if route is focused
+              ]}
+            >
+              {isFocused || width ? child : null}
+            </View>
+          );
+        })}
       </Animated.View>
     );
   }

--- a/src/TabViewPagerScroll.js
+++ b/src/TabViewPagerScroll.js
@@ -131,19 +131,23 @@ export default class TabViewPagerScroll<T: Route<*>>
         contentContainerStyle={layout.width ? null : styles.container}
         ref={this._setRef}
       >
-        {Children.map(children, (child, i) => (
-          <View
-            key={navigationState.routes[i].key}
-            testID={navigationState.routes[i].testID}
-            style={
-              layout.width
-                ? { width: layout.width, overflow: 'hidden' }
-                : i === navigationState.index ? styles.page : null
-            }
-          >
-            {i === navigationState.index || layout.width ? child : null}
-          </View>
-        ))}
+        {Children.map(children, (child, i) => {
+          const isFocused = i === navigationState.index;
+          return (
+            <View
+              key={navigationState.routes[i].key}
+              testID={navigationState.routes[i].testID}
+              style={[
+                layout.width
+                  ? { width: layout.width, overflow: 'hidden' }
+                  : isFocused ? styles.page : null,
+                { zIndex: isFocused ? 1000 : 0 }, // set zIndex to a high number if route is focused
+              ]}
+            >
+              {isFocused || layout.width ? child : null}
+            </View>
+          );
+        })}
       </ScrollView>
     );
   }


### PR DESCRIPTION
In react-navigation, we have a shadow on the edge of a card inside a CardStack. This shadow is usually offscreen. However, when you have two tabs, and a CardStack in each tab, the following happens (the shadow has been turned blue and increased in size to better demonstrate the issue):

![sample](http://s.sk3vy.com/kURd/Screen%20Shot%202017-05-16%20at%2010.49.32%20PM.png)

This PR adds a high zIndex to the focused child in TabViewPagerPan and TabViewPagerScroll, thus making sure the focused child is on top.