### PR TITLE
Revert "fix: remove unnecessary flexGrow"

### DIFF
--- a/src/TabViewPagerPan.js
+++ b/src/TabViewPagerPan.js
@@ -301,7 +301,7 @@ export default class TabViewPagerPan<T: Route<*>>
 
 const styles = StyleSheet.create({
   sheet: {
-    flex: 1,
+    flexGrow: 1,
     flexDirection: 'row',
     alignItems: 'stretch',
   },


### PR DESCRIPTION
This reverts commit 48741e7ea77d22e0b010a94d7985d186cf565539.

See discussion for details https://github.com/react-community/react-navigation/pull/1713#issuecomment-304831514
