### PR TITLE
Fix scroll failed when touch  tab of some phones like XiaoMi 5Plus.

### DIFF
--- a/src/TabViewPagerScroll.js
+++ b/src/TabViewPagerScroll.js
@@ -100,7 +100,7 @@ export default class TabViewPagerScroll<T: Route<*>>
   };
 
   _handleScroll = (e: ScrollEvent) => {
-    this._isIdle = e.nativeEvent.contentOffset.x === this._nextOffset;
+    this._isIdle = Math.abs(e.nativeEvent.contentOffset.x - this._nextOffset) < 0.1;
     this.props.position.setValue(
       e.nativeEvent.contentOffset.x / this.props.layout.width,
     );

--- a/src/TabViewPagerScroll.js
+++ b/src/TabViewPagerScroll.js
@@ -100,7 +100,8 @@ export default class TabViewPagerScroll<T: Route<*>>
   };
 
   _handleScroll = (e: ScrollEvent) => {
-    this._isIdle = Math.abs(e.nativeEvent.contentOffset.x - this._nextOffset) < 0.1;
+    this._isIdle =
+      Math.abs(e.nativeEvent.contentOffset.x - this._nextOffset) < 0.1;
     this.props.position.setValue(
       e.nativeEvent.contentOffset.x / this.props.layout.width,
     );


### PR DESCRIPTION
the scroll no work because of `e.nativeEvent.contentOffset.x ` and `this._nextOffset` are not  exactly equal when touch  tab of some phones like XiaoMi 5Plus.

```
_handleScroll e.nativeEvent.contentOffset.x 1178.1817626953125 this._nextOffset 1178.1817932128906
```
