### PR TITLE
Allow position prop for more control over behavior

### DIFF
--- a/src/TabViewAnimated.js
+++ b/src/TabViewAnimated.js
@@ -16,6 +16,11 @@ import type {
 } from './TabViewTypeDefinitions';
 
 type DefaultProps<T> = {
+  position: Animated.Value,
+  initialLayout: {
+    width: number,
+    height: number,
+  },
   renderPager: (
     props: SceneRendererProps<T> & PagerProps,
   ) => React.Element<any>,
@@ -35,6 +40,7 @@ type Props<T> = PagerProps & {
   renderFooter?: (props: SceneRendererProps<T>) => ?React.Element<any>,
   lazy?: boolean,
   style?: Style,
+  position: Animated.Value,
 };
 
 type State = {
@@ -79,6 +85,7 @@ export default class TabViewAnimated<T: Route<*>>
 
   static defaultProps = {
     renderPager: (props: SceneRendererProps<*>) => <TabViewPager {...props} />,
+    position: new Animated.Value(),
     initialLayout: {
       height: 0,
       width: 0,
@@ -88,13 +95,15 @@ export default class TabViewAnimated<T: Route<*>>
   constructor(props: Props<T>) {
     super(props);
 
+    props.position.setValue(this.props.navigationState.index);
+
     this.state = {
       loaded: [this.props.navigationState.index],
       layout: {
         ...this.props.initialLayout,
         measured: false,
       },
-      position: new Animated.Value(this.props.navigationState.index),
+      position: props.position,
     };
   }
 


### PR DESCRIPTION
Hey there! 

We are testing out swipeable tab implementations for our upcoming mobile app at @majorleaguesoccer and we really love this library! It works great right out of the box but we have a few situations in which we don't want the tab bar to be directly connected to the tab views due to intermediate content. We still want to sync tab behavior with tab view behavior because it allows for really nice animations like in the following example:

![jul-17-2017 14-24-05](https://user-images.githubusercontent.com/3629876/28283563-0ea7bff8-6afc-11e7-9313-90e62bb6b0d9.gif)
___


What that doesn't show is that the tab bar is in a collapsible header so it can't actually be rendered by the `TabViewAnimated` component:

![jul-17-2017 14-04-05](https://user-images.githubusercontent.com/3629876/28283604-2d8587a2-6afc-11e7-9ee3-1243c4db2ca6.gif)
___

My proposed solution is to allow users to pass in their own `postition` prop and providing a default if they don't. This inverts the control and allows the implementor to have full programmatic control over the positioning of tabs and also opens the door for syncing other animations with the views etc.

Im curious to hear your thoughts on this proposal!



