### PR TITLE
Add onSwipeStart and onSwipeEnd props to TabViewPagerPan

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Pager component based on `PanResponder`.
 - `swipeEnabled` - whether to enable swipe gestures
 - `swipeDistanceThreshold` - minimum swipe distance to trigger page switch
 - `swipeVelocityThreshold` - minimum swipe velocity to trigger page switch
+- `onSwipeStart` - optional callback when a swipe gesture starts
+- `onSwipeEnd` - optional callback when a swipe gesture ends
 - `children` - React Element(s) to render
 
 ### `<TabViewPagerScroll />`

--- a/src/TabViewPagerPan.js
+++ b/src/TabViewPagerPan.js
@@ -44,6 +44,8 @@ type GestureState = {
   numberActiveTouches: number,
 };
 
+type GestureHandler = (event: GestureEvent, state: GestureState) => void;
+
 type DefaultProps = {
   configureTransition: TransitionConfigurator,
   swipeDistanceThreshold: number,
@@ -56,8 +58,8 @@ type Props<T> = SceneRendererProps<T> & {
   swipeEnabled?: boolean,
   swipeDistanceThreshold: number,
   swipeVelocityThreshold: number,
-  onSwipeStart?: Function,
-  onSwipeEnd?: Function,
+  onSwipeStart?: GestureHandler,
+  onSwipeEnd?: GestureHandler,
   children?: React.Element<any>,
 };
 

--- a/src/TabViewPagerPan.js
+++ b/src/TabViewPagerPan.js
@@ -56,6 +56,8 @@ type Props<T> = SceneRendererProps<T> & {
   swipeEnabled?: boolean,
   swipeDistanceThreshold: number,
   swipeVelocityThreshold: number,
+  onSwipeStart?: Function,
+  onSwipeEnd?: Function,
   children?: React.Element<any>,
 };
 
@@ -76,6 +78,8 @@ export default class TabViewPagerPan<T: Route<*>>
     swipeEnabled: PropTypes.bool,
     swipeDistanceThreshold: PropTypes.number.isRequired,
     swipeVelocityThreshold: PropTypes.number.isRequired,
+    onSwipeStart: PropTypes.func,
+    onSwipeEnd: PropTypes.func,
     children: PropTypes.node,
   };
 
@@ -186,7 +190,10 @@ export default class TabViewPagerPan<T: Route<*>>
     return canMove;
   };
 
-  _startGesture = () => {
+  _startGesture = (evt: GestureEvent, gestureState: GestureState) => {
+    if (typeof this.props.onSwipeStart === 'function') {
+      this.props.onSwipeStart(evt, gestureState);
+    }
     this._lastValue = this.props.getLastPosition();
     this.props.position.stopAnimation();
   };
@@ -207,6 +214,9 @@ export default class TabViewPagerPan<T: Route<*>>
   };
 
   _finishGesture = (evt: GestureEvent, gestureState: GestureState) => {
+    if (typeof this.props.onSwipeEnd === 'function') {
+      this.props.onSwipeEnd(evt, gestureState);
+    }
     const currentIndex = this.props.navigationState.index;
     const currentValue = this.props.getLastPosition();
     if (currentValue !== currentIndex) {


### PR DESCRIPTION
There is a bug in React Native that makes gestures to conflict when a PanResponder is put inside of a ScrollView. The workaround for this is to listen to PanResponder start and finish events and toggle ScrollView's `scrollEnabled` accordingly.

Fixes #289 