### PR TITLE
Custom Nav Tabs Width

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -153,7 +153,7 @@ export default class TabBar<T: Route<*>> extends PureComponent<
   _isManualScroll: boolean = false;
   _isMomentumScroll: boolean = false;
 
-  _renderLabel = (scene: Scene<*>) => {
+  _renderLabel = (scene: Scene<*>, width: any) => {
     if (typeof this.props.renderLabel !== 'undefined') {
       return this.props.renderLabel(scene);
     }
@@ -161,8 +161,15 @@ export default class TabBar<T: Route<*>> extends PureComponent<
     if (typeof label !== 'string') {
       return null;
     }
+    let defaultStyle = [styles.tabLabel, this.props.labelStyle]
+    
+    if (width){
+      defaultStyle = this.props.labelStyle
+      defaultStyle.width = width
+    }
+
     return (
-      <Text style={[styles.tabLabel, this.props.labelStyle]}>
+      <Text style={defaultStyle}>
         {label}
       </Text>
     );
@@ -223,7 +230,15 @@ export default class TabBar<T: Route<*>> extends PureComponent<
     if (layout.width === 0) {
       return 0;
     }
-    const finalTabWidth = this._getFinalTabWidth(props);
+    let finalTabWidth = this._getFinalTabWidth(props);
+    if (this.props.tabWidths){
+      if (Array.isArray(this.props.tabWidths)){
+        finalTabWidth =  0
+        this.props.tabWidths.forEach((item)=>{
+          finalTabWidth += item
+        })
+      }
+    }
     const tabBarWidth = finalTabWidth * navigationState.routes.length;
     const maxDistance = tabBarWidth - layout.width;
     return Math.max(maxDistance, 0);
@@ -411,7 +426,15 @@ export default class TabBar<T: Route<*>> extends PureComponent<
                 focused,
                 index: i,
               };
-              const label = this._renderLabel(scene);
+              let customWidth = null
+              if (this.props.tabWidths){
+                if (Array.isArray(this.props.tabWidths)){
+                  if (this.props.tabWidths[i]){
+                    customWidth = this.props.tabWidths[i]
+                  }
+                }
+              }
+              const label = this._renderLabel(scene, customWidth);
               const icon = this.props.renderIcon
                 ? this.props.renderIcon(scene)
                 : null;


### PR DESCRIPTION
```
_renderHeader = props => {
    console.log(props)
    return (
      <TabBar
        {...props}
        scrollEnabled
        indicatorStyle={styles.indicator}
        style={styles.tabbar}
        tabStyle={styles.tab}
        labelStyle={styles.label}
        tabWidths={[180, 140, 40, 220, 200]}
      />
    );
  };
```
<img width="371" alt="screen shot 2017-07-19 at 5 17 56 pm" src="https://user-images.githubusercontent.com/4356002/28389981-3b9eb330-6ca6-11e7-8eec-47def9667a8d.png">
changes on stylle tab nav