### PR TITLE
Add prop to enable or not bouncing on TabBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Material design themed tab bar. Can be used as both top and bottom tab bar.
 - `pressColor` - color for material ripple (Android >= 5.0 only)
 - `pressOpacity` - opacity for pressed tab (iOS and Android < 5.0 only)
 - `scrollEnabled` - whether to enable scrollable tabs
+- `scrollViewBounces` - wether to enable bounce on tab bar ScrollView
 - `tabStyle` - style object for the individual tabs in the tab bar
 - `indicatorStyle` - style object for the active indicator
 - `labelStyle` - style object for the tab item label

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -38,6 +38,7 @@ type DefaultProps<T> = {
 
 type Props<T> = SceneRendererProps<T> & {
   scrollEnabled?: boolean,
+  scrollViewBounces?: boolean,
   pressColor?: string,
   pressOpacity?: number,
   getLabelText: (scene: Scene<T>) => ?string,
@@ -66,6 +67,7 @@ export default class TabBar<T: Route<*>> extends PureComponent<
   static propTypes = {
     ...SceneRendererPropType,
     scrollEnabled: PropTypes.bool,
+    scrollViewBounces: PropTypes.bool,
     pressColor: TouchableItem.propTypes.pressColor,
     pressOpacity: TouchableItem.propTypes.pressOpacity,
     getLabelText: PropTypes.func,
@@ -80,6 +82,7 @@ export default class TabBar<T: Route<*>> extends PureComponent<
   static defaultProps = {
     getLabelText: ({ route }) =>
       route.title ? route.title.toUpperCase() : null,
+    scrollViewBounces: false,
   };
 
   constructor(props: Props<T>) {
@@ -375,7 +378,7 @@ export default class TabBar<T: Route<*>> extends PureComponent<
           <ScrollView
             horizontal
             scrollEnabled={scrollEnabled}
-            bounces={false}
+            bounces={this.props.scrollViewBounces}
             alwaysBounceHorizontal={false}
             scrollsToTop={false}
             showsHorizontalScrollIndicator={false}


### PR DESCRIPTION
I suggest adding this little property allowing users to enable or not bouncing (its highly desirable on iOS for example) on `TabBar`'s `ScrollView` when scrolling is enabled.