### PR TITLE
Add prop to disable autofocus on page change or tab tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Material design themed tab bar. Can be used as both top and bottom tab bar.
 - `pressColor` - color for material ripple (Android >= 5.0 only)
 - `pressOpacity` - opacity for pressed tab (iOS and Android < 5.0 only)
 - `scrollEnabled` - whether to enable scrollable tabs
+- `autofocusTabAfterSelection` - whether TabBar should automatically show the current tab when state changes
 - `tabStyle` - style object for the individual tabs in the tab bar
 - `indicatorStyle` - style object for the active indicator
 - `labelStyle` - style object for the tab item label

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -38,6 +38,7 @@ type DefaultProps<T> = {
 
 type Props<T> = SceneRendererProps<T> & {
   scrollEnabled?: boolean,
+  autofocusTabAfterSelection?: boolean,
   pressColor?: string,
   pressOpacity?: number,
   getLabelText: (scene: Scene<T>) => ?string,
@@ -66,6 +67,7 @@ export default class TabBar<T: Route<*>> extends PureComponent<
   static propTypes = {
     ...SceneRendererPropType,
     scrollEnabled: PropTypes.bool,
+    autofocusTabAfterSelection: PropTypes.bool,
     pressColor: TouchableItem.propTypes.pressColor,
     pressOpacity: TouchableItem.propTypes.pressOpacity,
     getLabelText: PropTypes.func,
@@ -243,7 +245,11 @@ export default class TabBar<T: Route<*>> extends PureComponent<
   };
 
   _resetScrollOffset = (props: Props<T>) => {
-    if (!props.scrollEnabled || !this._scrollView) {
+    if (
+      !props.scrollEnabled ||
+      !this._scrollView ||
+      !this.props.autofocusTabAfterSelection
+    ) {
       return;
     }
 
@@ -262,7 +268,11 @@ export default class TabBar<T: Route<*>> extends PureComponent<
   };
 
   _adjustScroll = (index: number) => {
-    if (!this.props.scrollEnabled || !this._scrollView) {
+    if (
+      !this.props.scrollEnabled ||
+      !this._scrollView ||
+      !this.props.autofocusTabAfterSelection
+    ) {
       return;
     }
 
@@ -274,7 +284,11 @@ export default class TabBar<T: Route<*>> extends PureComponent<
   };
 
   _adjustOffset = (value: number) => {
-    if (!this._isManualScroll || !this.props.scrollEnabled) {
+    if (
+      !this._isManualScroll ||
+      !this.props.scrollEnabled ||
+      !this.props.autofocusTabAfterSelection
+    ) {
       return;
     }
 


### PR DESCRIPTION
I suggest a property to disable the current default of automatically focusing on page change (either tap in tabBar or swipe when swipe is enabled).