### PR TITLE
Add property to TabBar to custom focused tab's label

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Material design themed tab bar. Can be used as both top and bottom tab bar.
 - `tabStyle` - style object for the individual tabs in the tab bar
 - `indicatorStyle` - style object for the active indicator
 - `labelStyle` - style object for the tab item label
+- `focusedLabelStyle` - style object for the focused tab item label
 - `style` - style object for the tab bar
 
 

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -49,6 +49,7 @@ type Props<T> = SceneRendererProps<T> & {
   tabStyle?: Style,
   indicatorStyle?: Style,
   labelStyle?: Style,
+  focusedLabelStyle?: Style,
   style?: Style,
 };
 
@@ -161,8 +162,15 @@ export default class TabBar<T: Route<*>> extends PureComponent<
     if (typeof label !== 'string') {
       return null;
     }
+
     return (
-      <Text style={[styles.tabLabel, this.props.labelStyle]}>
+      <Text
+        style={[
+          styles.tabLabel,
+          this.props.labelStyle,
+          scene.focused ? this.props.focusedLabelStyle : null,
+        ]}
+      >
         {label}
       </Text>
     );


### PR DESCRIPTION
Another suggestion which makes it easier to customize focus appearance of tab bar item labels, actually it can only be done through the `_renderLabel` prop function and it's a bit complicated for just customizing the appearance of the default `<Text>`.