### PR TITLE
Update TabBar component to improve ripple effect

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -472,7 +472,7 @@ export default class TabBar<T: Route<*>> extends PureComponent<
                   }}
                   style={tabContainerStyle}
                 >
-                  <View pointerEvents={'none'} style={styles.container}>
+                  <View pointerEvents="none" style={styles.container}>
                     <Animated.View
                       style={[
                         styles.tabItem,

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -472,7 +472,7 @@ export default class TabBar<T: Route<*>> extends PureComponent<
                   }}
                   style={tabContainerStyle}
                 >
-                  <View style={styles.container}>
+                  <View pointerEvents={'none'} style={styles.container}>
                     <Animated.View
                       style={[
                         styles.tabItem,


### PR DESCRIPTION
This adds `pointerEvents={'none'}` to the `View` inside the `TouchableItem` to improve the ripple effect.

## Before

![tabs-ripple-before](https://user-images.githubusercontent.com/6205451/29166391-16a4186c-7dbe-11e7-9af4-18e07b362358.gif)

## After

![tabs-ripple-after](https://user-images.githubusercontent.com/6205451/29166395-1c277630-7dbe-11e7-8fa5-e2bc2b0ac345.gif)