### PR TITLE
fix : the position of tabbar is wrong when scrolling the pager manually.

### DIFF
--- a/__tests__/TabViewPagerPan.test.js
+++ b/__tests__/TabViewPagerPan.test.js
@@ -28,27 +28,45 @@ it('renders all children', () => {
     </TabViewPagerPan>
   );
 
-  expect(component.find({ testID: 'first' }).first().props().children).toBe(
-    null
-  );
   expect(
-    component.find({ testID: 'second' }).first().props().children
+    component
+      .find({ testID: 'first' })
+      .first()
+      .props().children
+  ).toBe(null);
+  expect(
+    component
+      .find({ testID: 'second' })
+      .first()
+      .props().children
   ).not.toBe(null);
-  expect(component.find({ testID: 'third' }).first().props().children).toBe(
-    null
-  );
+  expect(
+    component
+      .find({ testID: 'third' })
+      .first()
+      .props().children
+  ).toBe(null);
 
   component.setProps({
     layout: { height: 320, width: 240, measured: false },
   });
 
-  expect(component.find({ testID: 'first' }).first().props().children).not.toBe(
-    null
-  );
   expect(
-    component.find({ testID: 'second' }).first().props().children
+    component
+      .find({ testID: 'first' })
+      .first()
+      .props().children
   ).not.toBe(null);
-  expect(component.find({ testID: 'third' }).first().props().children).not.toBe(
-    null
-  );
+  expect(
+    component
+      .find({ testID: 'second' })
+      .first()
+      .props().children
+  ).not.toBe(null);
+  expect(
+    component
+      .find({ testID: 'third' })
+      .first()
+      .props().children
+  ).not.toBe(null);
 });

--- a/__tests__/TabViewPagerScroll.test.js
+++ b/__tests__/TabViewPagerScroll.test.js
@@ -31,29 +31,47 @@ it('renders only focused child until layout', () => {
     </TabViewPagerScroll>
   );
 
-  expect(component.find({ testID: 'first' }).first().props().children).toBe(
-    null
-  );
   expect(
-    component.find({ testID: 'second' }).first().props().children
+    component
+      .find({ testID: 'first' })
+      .first()
+      .props().children
+  ).toBe(null);
+  expect(
+    component
+      .find({ testID: 'second' })
+      .first()
+      .props().children
   ).not.toBe(null);
-  expect(component.find({ testID: 'third' }).first().props().children).toBe(
-    null
-  );
+  expect(
+    component
+      .find({ testID: 'third' })
+      .first()
+      .props().children
+  ).toBe(null);
 
   component.setProps({
     layout: { height: 320, width: 240, measured: false },
   });
 
-  expect(component.find({ testID: 'first' }).first().props().children).not.toBe(
-    null
-  );
   expect(
-    component.find({ testID: 'second' }).first().props().children
+    component
+      .find({ testID: 'first' })
+      .first()
+      .props().children
   ).not.toBe(null);
-  expect(component.find({ testID: 'third' }).first().props().children).not.toBe(
-    null
-  );
+  expect(
+    component
+      .find({ testID: 'second' })
+      .first()
+      .props().children
+  ).not.toBe(null);
+  expect(
+    component
+      .find({ testID: 'third' })
+      .first()
+      .props().children
+  ).not.toBe(null);
 });
 
 it('sets initial scroll position according to navigation state index', () => {

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -146,32 +146,30 @@ export default class ExampleList extends PureComponent {
               : null,
           ]}
         >
-          {index > -1
-            ? <TouchableOpacity
-                style={styles.button}
-                onPress={this._handleNavigateBack}
-              >
-                <Ionicons
-                  name={
-                    Platform.OS === 'android'
-                      ? 'md-arrow-back'
-                      : 'ios-arrow-back'
-                  }
-                  size={24}
-                  color={tintColor}
-                />
-              </TouchableOpacity>
-            : null}
+          {index > -1 ? (
+            <TouchableOpacity
+              style={styles.button}
+              onPress={this._handleNavigateBack}
+            >
+              <Ionicons
+                name={
+                  Platform.OS === 'android' ? 'md-arrow-back' : 'ios-arrow-back'
+                }
+                size={24}
+                color={tintColor}
+              />
+            </TouchableOpacity>
+          ) : null}
           <Text style={[styles.title, tintColor ? { color: tintColor } : null]}>
             {index > -1 ? EXAMPLE_COMPONENTS[index].title : this.state.title}
           </Text>
           {index > -1 ? <View style={styles.button} /> : null}
         </View>
-        {index === -1
-          ? <ScrollView>
-              {EXAMPLE_COMPONENTS.map(this._renderItem)}
-            </ScrollView>
-          : ExampleComponent ? <ExampleComponent /> : null}
+        {index === -1 ? (
+          <ScrollView>{EXAMPLE_COMPONENTS.map(this._renderItem)}</ScrollView>
+        ) : ExampleComponent ? (
+          <ExampleComponent />
+        ) : null}
       </View>
     );
   }

--- a/example/src/BasicListView.js
+++ b/example/src/BasicListView.js
@@ -38,9 +38,7 @@ export default class ListViewExample extends PureComponent {
   _renderRow = index => {
     return (
       <View style={styles.row}>
-        <Text style={styles.text}>
-          {index}
-        </Text>
+        <Text style={styles.text}>{index}</Text>
       </View>
     );
   };

--- a/example/src/CoverflowExample.js
+++ b/example/src/CoverflowExample.js
@@ -100,9 +100,7 @@ export default class CoverflowExample extends PureComponent<void, *, State> {
         <View style={styles.album}>
           <Image source={ALBUMS[props.route.key]} style={styles.cover} />
         </View>
-        <Text style={styles.label}>
-          {props.route.key}
-        </Text>
+        <Text style={styles.label}>{props.route.key}</Text>
       </Animated.View>
     );
   };

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -117,7 +117,6 @@ export default class TabBar<T: Route<*>> extends PureComponent<
   }
 
   componentWillReceiveProps(nextProps: Props<T>) {
-
     const nextTabWidth = this._getTabWidthFromStyle(nextProps.tabStyle);
 
     if (
@@ -159,9 +158,7 @@ export default class TabBar<T: Route<*>> extends PureComponent<
       return null;
     }
     return (
-      <Text style={[styles.tabLabel, this.props.labelStyle]}>
-        {label}
-      </Text>
+      <Text style={[styles.tabLabel, this.props.labelStyle]}>{label}</Text>
     );
   };
 
@@ -462,16 +459,16 @@ export default class TabBar<T: Route<*>> extends PureComponent<
                       {icon}
                       {label}
                     </Animated.View>
-                    {badge
-                      ? <Animated.View
-                          style={[
-                            styles.badge,
-                            { opacity: this.state.visibility },
-                          ]}
-                        >
-                          {badge}
-                        </Animated.View>
-                      : null}
+                    {badge ? (
+                      <Animated.View
+                        style={[
+                          styles.badge,
+                          { opacity: this.state.visibility },
+                        ]}
+                      >
+                        {badge}
+                      </Animated.View>
+                    ) : null}
                   </View>
                 </TouchableItem>
               );

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -117,9 +117,6 @@ export default class TabBar<T: Route<*>> extends PureComponent<
   }
 
   componentWillReceiveProps(nextProps: Props<T>) {
-    if (this.props.navigationState !== nextProps.navigationState) {
-      this._resetScrollOffset(nextProps);
-    }
 
     const nextTabWidth = this._getTabWidthFromStyle(nextProps.tabStyle);
 
@@ -240,25 +237,6 @@ export default class TabBar<T: Route<*>> extends PureComponent<
     const centerDistance = finalTabWidth * i + finalTabWidth / 2;
     const scrollAmount = centerDistance - layout.width / 2;
     return this._normalizeScrollValue(props, scrollAmount);
-  };
-
-  _resetScrollOffset = (props: Props<T>) => {
-    if (!props.scrollEnabled || !this._scrollView) {
-      return;
-    }
-
-    const scrollAmount = this._getScrollAmount(
-      props,
-      props.navigationState.index
-    );
-    this._scrollView.scrollTo({
-      x: scrollAmount,
-      animated: true,
-    });
-    Animated.timing(this.state.offset, {
-      toValue: 0,
-      duration: 150,
-    }).start();
   };
 
   _adjustScroll = (index: number) => {

--- a/src/TabViewPagerAndroid.js
+++ b/src/TabViewPagerAndroid.js
@@ -133,7 +133,7 @@ export default class TabViewPagerAndroid<T: Route<*>> extends PureComponent<
 
   render() {
     const { children, navigationState, swipeEnabled } = this.props;
-    const content = Children.map(children, (child, i) =>
+    const content = Children.map(children, (child, i) => (
       <View
         key={navigationState.routes[i].key}
         testID={navigationState.routes[i].testID}
@@ -141,7 +141,7 @@ export default class TabViewPagerAndroid<T: Route<*>> extends PureComponent<
       >
         {child}
       </View>
-    );
+    ));
 
     if (I18nManager.isRTL) {
       content.reverse();

--- a/src/TabViewPagerPan.js
+++ b/src/TabViewPagerPan.js
@@ -298,7 +298,7 @@ export default class TabViewPagerPan<T: Route<*>> extends PureComponent<
         ]}
         {...this._panResponder.panHandlers}
       >
-        {Children.map(children, (child, i) =>
+        {Children.map(children, (child, i) => (
           <View
             key={navigationState.routes[i].key}
             testID={navigationState.routes[i].testID}
@@ -310,7 +310,7 @@ export default class TabViewPagerPan<T: Route<*>> extends PureComponent<
           >
             {i === navigationState.index || width ? child : null}
           </View>
-        )}
+        ))}
       </Animated.View>
     );
   }

--- a/src/TabViewPagerScroll.js
+++ b/src/TabViewPagerScroll.js
@@ -135,7 +135,7 @@ export default class TabViewPagerScroll<T: Route<*>> extends PureComponent<
         contentContainerStyle={layout.width ? null : styles.container}
         ref={this._setRef}
       >
-        {Children.map(children, (child, i) =>
+        {Children.map(children, (child, i) => (
           <View
             key={navigationState.routes[i].key}
             testID={navigationState.routes[i].testID}
@@ -147,7 +147,7 @@ export default class TabViewPagerScroll<T: Route<*>> extends PureComponent<
           >
             {i === navigationState.index || layout.width ? child : null}
           </View>
-        )}
+        ))}
       </ScrollView>
     );
   }

--- a/src/TouchableItem.js
+++ b/src/TouchableItem.js
@@ -59,9 +59,7 @@ export default class TouchableItem extends PureComponent<
           onPress={this._handlePress}
           background={TouchableNativeFeedback.Ripple(pressColor, borderless)}
         >
-          <View style={style}>
-            {Children.only(this.props.children)}
-          </View>
+          <View style={style}>{Children.only(this.props.children)}</View>
         </TouchableNativeFeedback>
       );
     } else {


### PR DESCRIPTION
Before：

![](https://raw.githubusercontent.com/jiangleo/react-native-tab-view/doc/image/111111.gif)

After:
![](https://raw.githubusercontent.com/jiangleo/react-native-tab-view/doc/image/22222.gif)

`scrollAmount` is set by `_resetScrollOffset` and `_adjustScroll`, but only need `_resetScrollOffset`.
