### PR TITLE
Add accessibilityLable to TabBar.js

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -42,6 +42,7 @@ type Props<T> = SceneRendererProps<T> & {
   pressOpacity?: number,
   getLabelText: (scene: Scene<T>) => ?string,
   renderLabel?: (scene: Scene<T>) => ?React.Element<any>,
+  getAccessibilityLabel?: (scene: Scene<T>) => ?string,
   renderIcon?: (scene: Scene<T>) => ?React.Element<any>,
   renderBadge?: (scene: Scene<T>) => ?React.Element<any>,
   renderIndicator?: (props: IndicatorProps<T>) => ?React.Element<any>,
@@ -162,6 +163,12 @@ export default class TabBar<T: Route<*>>
       <Text style={[styles.tabLabel, this.props.labelStyle]}>{label}</Text>
     );
   };
+
+  _getAccessibility = (scene: Scene<*>) => {
+    if (typeof this.props.getAccessibilityLabel !== 'undefined') {
+      return this.props.getAccessibilityLabel(scene);
+    }
+  }
 
   _renderIndicator = (props: IndicatorProps<T>) => {
     if (typeof this.props.renderIndicator !== 'undefined') {
@@ -443,8 +450,9 @@ export default class TabBar<T: Route<*>>
                 tabContainerStyle.flex = 1;
               }
 
-              const accessibilityLabel =
-                route.accessibilityLabel || route.title;
+              const accessibilityLabel = route.accessibilityLabel
+                || route.title
+                || this._getAccessibility(scene);
 
               return (
                 <TouchableItem

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -58,11 +58,8 @@ type State = {
   initialOffset: { x: number, y: number },
 };
 
-export default class TabBar<T: Route<*>> extends PureComponent<
-  DefaultProps<T>,
-  Props<T>,
-  State
-> {
+export default class TabBar<T: Route<*>>
+  extends PureComponent<DefaultProps<T>, Props<T>, State> {
   static propTypes = {
     ...SceneRendererPropType,
     scrollEnabled: PropTypes.bool,
@@ -112,7 +109,7 @@ export default class TabBar<T: Route<*>> extends PureComponent<
     this._adjustScroll(this.props.navigationState.index);
     this._positionListener = this.props.subscribe(
       'position',
-      this._adjustScroll
+      this._adjustScroll,
     );
   }
 
@@ -126,7 +123,7 @@ export default class TabBar<T: Route<*>> extends PureComponent<
     if (
       (this.props.tabStyle !== nextProps.tabStyle && nextTabWidth) ||
       (this.props.layout.width !== nextProps.layout.width &&
-        nextProps.layout.width)
+      nextProps.layout.width)
     ) {
       this.state.visibility.setValue(1);
     }
@@ -136,10 +133,10 @@ export default class TabBar<T: Route<*>> extends PureComponent<
     if (
       this.props.scrollEnabled &&
       (prevProps.layout !== this.props.layout ||
-        prevProps.tabStyle !== this.props.tabStyle)
+      prevProps.tabStyle !== this.props.tabStyle)
     ) {
       global.requestAnimationFrame(() =>
-        this._adjustScroll(this.props.navigationState.index)
+        this._adjustScroll(this.props.navigationState.index),
       );
     }
   }
@@ -162,9 +159,7 @@ export default class TabBar<T: Route<*>> extends PureComponent<
       return null;
     }
     return (
-      <Text style={[styles.tabLabel, this.props.labelStyle]}>
-        {label}
-      </Text>
+      <Text style={[styles.tabLabel, this.props.labelStyle]}>{label}</Text>
     );
   };
 
@@ -175,7 +170,7 @@ export default class TabBar<T: Route<*>> extends PureComponent<
     const { width, position } = props;
     const translateX = Animated.multiply(
       Animated.multiply(position, width),
-      I18nManager.isRTL ? -1 : 1
+      I18nManager.isRTL ? -1 : 1,
     );
     return (
       <Animated.View
@@ -249,7 +244,7 @@ export default class TabBar<T: Route<*>> extends PureComponent<
 
     const scrollAmount = this._getScrollAmount(
       props,
-      props.navigationState.index
+      props.navigationState.index,
     );
     this._scrollView.scrollTo({
       x: scrollAmount,
@@ -280,7 +275,7 @@ export default class TabBar<T: Route<*>> extends PureComponent<
 
     const scrollAmount = this._getScrollAmount(
       this.props,
-      this.props.navigationState.index
+      this.props.navigationState.index,
     );
     const scrollOffset = value - scrollAmount;
 
@@ -340,7 +335,7 @@ export default class TabBar<T: Route<*>> extends PureComponent<
     // Prepend '-1', so there are always at least 2 items in inputRange
     const inputRange = [-1, ...routes.map((x, i) => i)];
     const translateOutputRange = inputRange.map(
-      i => this._getScrollAmount(this.props, i) * -1
+      i => this._getScrollAmount(this.props, i) * -1,
     );
 
     const translateX = Animated.add(
@@ -348,7 +343,7 @@ export default class TabBar<T: Route<*>> extends PureComponent<
         inputRange,
         outputRange: translateOutputRange,
       }),
-      this.state.offset
+      this.state.offset,
     ).interpolate({
       inputRange: [-maxDistance, 0],
       outputRange: [-maxDistance, 0],
@@ -397,14 +392,14 @@ export default class TabBar<T: Route<*>> extends PureComponent<
             {routes.map((route, i) => {
               const focused = index === i;
               const outputRange = inputRange.map(
-                inputIndex => (inputIndex === i ? 1 : 0.7)
+                inputIndex => (inputIndex === i ? 1 : 0.7),
               );
               const opacity = Animated.multiply(
                 this.state.visibility,
                 position.interpolate({
                   inputRange,
                   outputRange,
-                })
+                }),
               );
               const scene = {
                 route,
@@ -434,7 +429,7 @@ export default class TabBar<T: Route<*>> extends PureComponent<
               const passedTabStyle = StyleSheet.flatten(this.props.tabStyle);
               const isWidthSet =
                 (passedTabStyle &&
-                  typeof passedTabStyle.width !== 'undefined') ||
+                typeof passedTabStyle.width !== 'undefined') ||
                 scrollEnabled === true;
               const tabContainerStyle = {};
 
@@ -486,13 +481,13 @@ export default class TabBar<T: Route<*>> extends PureComponent<
                     </Animated.View>
                     {badge
                       ? <Animated.View
-                          style={[
-                            styles.badge,
-                            { opacity: this.state.visibility },
-                          ]}
-                        >
-                          {badge}
-                        </Animated.View>
+                        style={[
+                          styles.badge,
+                          { opacity: this.state.visibility },
+                        ]}
+                      >
+                        {badge}
+                      </Animated.View>
                       : null}
                   </View>
                 </TouchableItem>


### PR DESCRIPTION
I added getaccessibilityLabel to TabBar so that anyone who is going to use this library can pass accessibilityLabel and it will show up in the tab. Before I added the change, TabBar will take the accessibilityLabel from route, if route does not have any accessibility label, it will then use the title. 


Some background information: 
In some project, somehow route will set accessibility label as same as title.  