### PR TITLE
Add safety check to _resetListener

### DIFF
--- a/src/TabViewPagerPan.js
+++ b/src/TabViewPagerPan.js
@@ -121,7 +121,7 @@ export default class TabViewPagerPan<T: Route<*>> extends PureComponent<
   }
 
   componentWillUnmount() {
-    this._resetListener.remove();
+    this._resetListener && this._resetListener.remove();
   }
 
   _panResponder: Object;


### PR DESCRIPTION
For some reason whenever my Expo app throws an error this small error will get captured instead.

For example if I don't import `Text` from `react-native` but then try and use `Text`. The red screen will show `undefined is not an object (evaluating 'this._resetListener.remove')` somewhere. My guess is a try catch somewhere is causing this misdirection. Added a simple safety to this line allows me to properly see my errors.


BTW Love the library so far, thanks for all your work!