### PR TITLE
Update TabViewPagerAndroid with safety check on _resetListener

### DIFF
--- a/src/TabViewPagerAndroid.js
+++ b/src/TabViewPagerAndroid.js
@@ -66,7 +66,7 @@ export default class TabViewPagerAndroid<T: Route<*>> extends React.Component<
   }
 
   componentWillUnmount() {
-    this._resetListener.remove();
+    this._resetListener && this._resetListener.remove();
   }
 
   _animationFrameCallback: ?() => void;


### PR DESCRIPTION
Similar to issue #365 , when react-native throws an error, this error is thrown instead as `undefined is not an object (evaluating 'this._resetListener.remove')`. 

This makes debugging the original problem much harder.

Not sure why practically any errors in react-native causes the `_resetListener` to be undefined, but in the mean time, this solution stops the problem.