### PR TITLE
[FIX] Animated devided by zero

### DIFF
--- a/src/TabViewAnimated.js
+++ b/src/TabViewAnimated.js
@@ -132,6 +132,10 @@ export default class TabViewAnimated<T: *> extends React.Component<
       return;
     }
 
+    if (!height || !width) {
+      return;
+    }
+
     this.state.offsetX.setValue(-this.props.navigationState.index * width);
     this.state.layoutXY.setValue({
       // This is hacky, but we need to make sure that the value is never 0


### PR DESCRIPTION
We are using this library with `wix/react-native-navigation` and have some issues with the error described in issue #413 .

This PR prevents the application from crashing if one of `height` or `width` cant be measured for some reason during the onLayout lifecycle.