### PR TITLE
When used with react-native-web, do not expect ViewPagerAndroid to be supported

### DIFF
--- a/example/src/NoAnimationExample.js
+++ b/example/src/NoAnimationExample.js
@@ -93,7 +93,7 @@ export default class TopBarIconExample extends React.Component<*, State> {
         return (
           <TouchableWithoutFeedback
             key={route.key}
-            onPress={() => props.jumpToIndex(index)}
+            onPress={() => props.jumpTo(route.key)}
           >
             <Animated.View style={styles.tab}>
               {this._renderIcon(props)({ route, index })}

--- a/src/TabViewPagerAndroid.web.js
+++ b/src/TabViewPagerAndroid.web.js
@@ -1,0 +1,6 @@
+import { Text } from 'react-native';
+
+export default TabViewPagerAndroid = () => (
+  <Text>The TabViewPagerAndroid is not supported on React Native Web</Text>
+)
+

--- a/src/TabViewPagerAndroid.web.js
+++ b/src/TabViewPagerAndroid.web.js
@@ -1,6 +1,12 @@
+import React from 'react';
 import { Text } from 'react-native';
 
-export default TabViewPagerAndroid = () => (
-  <Text>The TabViewPagerAndroid is not supported on React Native Web</Text>
-)
-
+export default class TabViewPagerAndroid<T: *> extends React.Component<
+  Props<T>
+> {
+  render() {
+    return (
+      <Text>The TabViewPagerAndroid is not supported on React Native Web</Text>
+    );
+  }
+}


### PR DESCRIPTION
react-native-web aliases `import ... from 'react-native'` into `import ... from 'react-native-web'`.
But it does not implement undocumented or iOS/Android-only components, not even stubs for it.
So I added a stub in this package, which provides a component which just says: not implemented.