### PR TITLE
Check if NativeAnimatedModules is available before defaulting to useNativeDriver in TabBar

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -4,12 +4,15 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import {
   Animated,
+  NativeModules,
   StyleSheet,
   View,
   ScrollView,
   Platform,
   I18nManager,
 } from 'react-native';
+const NativeAnimatedModule = NativeModules.NativeAnimatedModule;
+
 import TouchableItem from './TouchableItem';
 import { SceneRendererPropType } from './TabViewPropTypes';
 import type {
@@ -379,7 +382,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
                   },
                 },
               ],
-              { useNativeDriver: true, listener: this._handleScroll }
+              { useNativeDriver: !!NativeAnimatedModule, listener: this._handleScroll }
             )}
             onScrollBeginDrag={this._handleBeginDrag}
             onScrollEndDrag={this._handleEndDrag}

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -11,7 +11,6 @@ import {
   Platform,
   I18nManager,
 } from 'react-native';
-
 import TouchableItem from './TouchableItem';
 import { SceneRendererPropType } from './TabViewPropTypes';
 import type {

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -11,7 +11,6 @@ import {
   Platform,
   I18nManager,
 } from 'react-native';
-const NativeAnimatedModule = NativeModules.NativeAnimatedModule;
 
 import TouchableItem from './TouchableItem';
 import { SceneRendererPropType } from './TabViewPropTypes';
@@ -46,6 +45,8 @@ type State = {|
   scrollAmount: Animated.Value,
   initialOffset: ?{| x: number, y: number |},
 |};
+
+const useNativeDriver = Boolean(NativeModules.NativeAnimatedModule);
 
 export default class TabBar<T: *> extends React.Component<Props<T>, State> {
   static propTypes = {
@@ -382,7 +383,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
                   },
                 },
               ],
-              { useNativeDriver: !!NativeAnimatedModule, listener: this._handleScroll }
+              { useNativeDriver, listener: this._handleScroll }
             )}
             onScrollBeginDrag={this._handleBeginDrag}
             onScrollEndDrag={this._handleEndDrag}


### PR DESCRIPTION
When running the TabBar on react-native-web, I got a warning that the Native Animation was not available. This implements the check, and prevents the warning.

