### PR TITLE
Use internal current index in TabViewPagerPan instead of the one from props

### DIFF
--- a/example/src/CoverflowExample.js
+++ b/example/src/CoverflowExample.js
@@ -50,8 +50,7 @@ export default class CoverflowExample extends React.Component<*, State> {
     const { width } = layout;
     const { routes } = navigationState;
     const currentIndex = routes.indexOf(route);
-    // Prepend '-1', so there are always at least 2 items in inputRange
-    const inputRange = [-1, ...routes.map((x, i) => i)];
+    const inputRange = routes.map((x, i) => i);
     const translateOutputRange = inputRange.map(i => {
       return width / 2 * (currentIndex - i) * -1;
     });
@@ -73,14 +72,17 @@ export default class CoverflowExample extends React.Component<*, State> {
     const translateX = position.interpolate({
       inputRange,
       outputRange: translateOutputRange,
+      extrapolate: 'clamp',
     });
     const scale = position.interpolate({
       inputRange,
       outputRange: scaleOutputRange,
+      extrapolate: 'clamp',
     });
     const opacity = position.interpolate({
       inputRange,
       outputRange: opacityOutputRange,
+      extrapolate: 'clamp',
     });
 
     return {

--- a/src/TabViewPagerPan.js
+++ b/src/TabViewPagerPan.js
@@ -79,6 +79,11 @@ export default class TabViewPagerPan<T: *> extends React.Component<Props<T>> {
     },
   };
 
+  constructor(props: Props<T>) {
+    super(props);
+    this._currentIndex = this.props.navigationState.index;
+  }
+
   componentWillMount() {
     this._panResponder = PanResponder.create({
       onMoveShouldSetPanResponder: this._canMoveScreen,
@@ -93,9 +98,12 @@ export default class TabViewPagerPan<T: *> extends React.Component<Props<T>> {
 
   componentDidUpdate(prevProps: Props<T>) {
     if (prevProps.navigationState.index !== this.props.navigationState.index) {
+      this._currentIndex = this.props.navigationState.index;
       this._transitionTo(this.props.navigationState.index);
     }
   }
+
+  _currentIndex: number;
 
   _isMovingHorizontally = (evt: GestureEvent, gestureState: GestureState) => {
     return (
@@ -109,12 +117,13 @@ export default class TabViewPagerPan<T: *> extends React.Component<Props<T>> {
       return false;
     }
 
-    const { navigationState: { routes, index } } = this.props;
+    const { navigationState: { routes } } = this.props;
 
     return (
       this._isMovingHorizontally(evt, gestureState) &&
-      ((gestureState.dx >= DEAD_ZONE && index >= 0) ||
-        (gestureState.dx <= -DEAD_ZONE && index <= routes.length - 1))
+      ((gestureState.dx >= DEAD_ZONE && this._currentIndex > 0) ||
+        (gestureState.dx <= -DEAD_ZONE &&
+          this._currentIndex < routes.length - 1))
     );
   };
 
@@ -159,7 +168,7 @@ export default class TabViewPagerPan<T: *> extends React.Component<Props<T>> {
     const currentIndex =
       typeof this._pendingIndex === 'number'
         ? this._pendingIndex
-        : navigationState.index;
+        : this._currentIndex;
 
     let nextIndex = currentIndex;
 
@@ -178,6 +187,7 @@ export default class TabViewPagerPan<T: *> extends React.Component<Props<T>> {
           navigationState.routes.length - 1
         )
       );
+      this._currentIndex = nextIndex;
     }
 
     if (


### PR DESCRIPTION
Index from `props` might be out of sync due to async nature of `setState`.

### Motivation

Fixes #448 

### Test plan

Manual testing due to specific nature of the problem.