### PR TITLE
Added active label style prop in the top bar.

### DIFF
--- a/example/src/TopBarTextExample.js
+++ b/example/src/TopBarTextExample.js
@@ -50,6 +50,7 @@ export default class TopBarTextExample extends React.Component<*, State> {
       style={styles.tabbar}
       tabStyle={styles.tab}
       labelStyle={styles.label}
+      activeLabelStyle={styles.activeLabel}
     />
   );
 
@@ -88,7 +89,11 @@ const styles = StyleSheet.create({
     backgroundColor: '#ffeb3b',
   },
   label: {
-    color: '#fff',
+    color: '#d3d3d3',
     fontWeight: '400',
+  },
+  activeLabel: {
+    color: '#fff',
+    fontWeight: 'bold',
   },
 });

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -36,6 +36,7 @@ type Props<T> = SceneRendererProps<T> & {
   tabStyle?: Style,
   indicatorStyle?: Style,
   labelStyle?: Style,
+  activeLabelStyle?: Style,
   style?: Style,
 };
 
@@ -168,7 +169,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
     this._adjustScroll(value);
   };
 
-  _renderLabel = (scene: Scene<*>) => {
+  _renderLabel = (scene: Scene<*>, focused: boolean) => {
     if (typeof this.props.renderLabel !== 'undefined') {
       return this.props.renderLabel(scene);
     }
@@ -177,7 +178,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
       return null;
     }
     return (
-      <Animated.Text style={[styles.tabLabel, this.props.labelStyle]}>
+      <Animated.Text style={[styles.tabLabel, this.props.labelStyle, focused ? this.props.activeLabelStyle : {}]}>
         {label}
       </Animated.Text>
     );
@@ -408,7 +409,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
                 focused,
                 index: i,
               };
-              const label = this._renderLabel(scene);
+              const label = this._renderLabel(scene, focused);
               const icon = this.props.renderIcon
                 ? this.props.renderIcon(scene)
                 : null;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

As of today, there is no way to pass styles that indicate active label in TabBar. In my pull request, I've added new prop that enables user to specify styles of active label. To do this, you need to pass prop I've called `activeLabelStyle`. I've added this case to `TopBadTextExample.js` so that you can see how this works.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Pass `activeLabelStyle` prop to TabBar to indicate with style of an active tab (see screenshot below):

![29103593_10157178962752802_1735794565773787136_n](https://user-images.githubusercontent.com/9539850/37270897-dfae2f12-25d0-11e8-958c-ed24f9dd8fda.jpg)
