### PR TITLE
Add deprecation warning to jumpToIndex

### DIFF
--- a/src/SceneMap.js
+++ b/src/SceneMap.js
@@ -9,7 +9,12 @@ export default function SceneMap(scenes: { [key: string]: Function }) {
     }
   }
 
-  return ({ route, jumpTo }: *) => (
-    <SceneComponent key={route.key} route={route} jumpTo={jumpTo} />
+  return ({ route, jumpTo, jumpToIndex }: *) => (
+    <SceneComponent
+      key={route.key}
+      route={route}
+      jumpTo={jumpTo}
+      jumpToIndex={jumpToIndex}
+    />
   );
 }

--- a/src/TabViewAnimated.js
+++ b/src/TabViewAnimated.js
@@ -152,8 +152,20 @@ export default class TabViewAnimated<T: *> extends React.Component<
     layout: this.state.layout,
     navigationState: this.props.navigationState,
     jumpTo: this._jumpTo,
+    jumpToIndex: this._jumpToIndex,
     useNativeDriver: this.props.useNativeDriver === true,
   });
+
+  _jumpToIndex = (index: number) => {
+    const { key } = this.props.navigationState.routes[index];
+
+    console.warn(
+      'Method `jumpToIndex` is deprecated. Please upgrade your code to use `jumpTo` instead.',
+      `Change your code from \`jumpToIndex(${index})\` to \`jumpTo('${key}').\``
+    );
+
+    this._jumpTo(key);
+  };
 
   _jumpTo = (key: string) => {
     if (!this._mounted) {

--- a/src/TabViewPropTypes.js
+++ b/src/TabViewPropTypes.js
@@ -24,6 +24,7 @@ export const SceneRendererPropType = {
   navigationState: NavigationStatePropType.isRequired,
   position: PropTypes.object.isRequired,
   jumpTo: PropTypes.func.isRequired,
+  jumpToIndex: PropTypes.func.isRequired, // Deprecated, use `jumpTo` instead
   useNativeDriver: PropTypes.bool,
 };
 

--- a/src/TabViewTypeDefinitions.js
+++ b/src/TabViewTypeDefinitions.js
@@ -31,6 +31,7 @@ export type SceneRendererProps<T> = {
   offsetX: Animated.Value,
   position: any,
   jumpTo: (key: string) => void,
+  jumpToIndex: (index: number) => void, // Deprecated, use `jumpTo` instead
   useNativeDriver: boolean,
 };
 


### PR DESCRIPTION
### Motivation

Fix #467 

### Test plan

Change `example/src/NoAnimationExample.js` line 99:

```diff
         return (
           <TouchableWithoutFeedback
             key={route.key}
-            onPress={() => props.jumpTo(route.key)}
+            onPress={() => props.jumpToIndex(index)}
           >
             <Animated.View style={styles.tab}>
               {this._renderIcon(props)({ route, index })}
```

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
