### PR TITLE
Disable animation when jumping to tab far away

### DIFF
--- a/example/src/TopBarTextExample.js
+++ b/example/src/TopBarTextExample.js
@@ -47,6 +47,7 @@ export default class TopBarTextExample extends React.Component<*, State> {
       {...props}
       scrollEnabled
       indicatorStyle={styles.indicator}
+      indicatorBaseLineViewStyle={styles.indicatorBaseLineView}
       style={styles.tabbar}
       tabStyle={styles.tab}
       labelStyle={styles.label}
@@ -86,6 +87,9 @@ const styles = StyleSheet.create({
   },
   indicator: {
     backgroundColor: '#ffeb3b',
+  },
+  indicatorBaseLineView: {
+    backgroundColor: '#E91F63',
   },
   label: {
     color: '#fff',

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -36,6 +36,7 @@ type Props<T> = SceneRendererProps<T> & {
   onTabPress?: (scene: Scene<T>) => void,
   tabStyle?: Style,
   indicatorStyle?: Style,
+  indicatorBaseLineViewStyle?: Style,
   labelStyle?: Style,
   style?: Style,
 };
@@ -353,6 +354,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
               : null,
           ]}
         >
+          <View style={[styles.indicator, this.props.indicatorBaseLineViewStyle]}></View>
           {this._renderIndicator({
             ...this.props,
             width: tabWidth,

--- a/src/TabViewPagerScroll.js
+++ b/src/TabViewPagerScroll.js
@@ -152,7 +152,7 @@ export default class TabViewPagerScroll<T: *> extends React.Component<
         overScrollMode="never"
         scrollEnabled={this.props.swipeEnabled}
         automaticallyAdjustContentInsets={false}
-        bounces={false}
+        bounces={true}
         alwaysBounceHorizontal={false}
         scrollsToTop={false}
         showsHorizontalScrollIndicator={false}

--- a/src/TabViewPagerScroll.js
+++ b/src/TabViewPagerScroll.js
@@ -163,8 +163,6 @@ export default class TabViewPagerScroll<T: *> extends React.Component<
         contentOffset={this.state.initialOffset}
         style={styles.container}
         contentContainerStyle={layout.width ? null : styles.container}
-        onStartShouldSetResponderCapture = {(evt) => true}
-        onMoveShouldSetResponderCapture = {(evt) => true}
         ref={el => (this._scrollView = el)}
       >
         {React.Children.map(children, (child, i) => (

--- a/src/TabViewPagerScroll.js
+++ b/src/TabViewPagerScroll.js
@@ -62,7 +62,7 @@ export default class TabViewPagerScroll<T: *> extends React.Component<
       prevProps.navigationState !== this.props.navigationState
     ) {
       let animated = prevProps.layout.width === this.props.layout.width;
-      if (Math.abs(prevProps.navigationState.index - this.props.navigationState.index) > 3) {
+      if (Math.abs(prevProps.navigationState.index - this.props.navigationState.index) > 0) { //totally disable tab scene switching animation
         animated = false;
       }
       this._scrollTo(

--- a/src/TabViewPagerScroll.js
+++ b/src/TabViewPagerScroll.js
@@ -163,6 +163,8 @@ export default class TabViewPagerScroll<T: *> extends React.Component<
         contentOffset={this.state.initialOffset}
         style={styles.container}
         contentContainerStyle={layout.width ? null : styles.container}
+        onStartShouldSetResponderCapture = {(evt) => true}
+        onMoveShouldSetResponderCapture = {(evt) => true}
         ref={el => (this._scrollView = el)}
       >
         {React.Children.map(children, (child, i) => (

--- a/src/TabViewPagerScroll.js
+++ b/src/TabViewPagerScroll.js
@@ -61,9 +61,13 @@ export default class TabViewPagerScroll<T: *> extends React.Component<
       prevProps.layout.width !== this.props.layout.width ||
       prevProps.navigationState !== this.props.navigationState
     ) {
+      let animated = prevProps.layout.width === this.props.layout.width;
+      if (Math.abs(prevProps.navigationState.index - this.props.navigationState.index) > 3) {
+        animated = false;
+      }
       this._scrollTo(
         this.props.navigationState.index * this.props.layout.width,
-        prevProps.layout.width === this.props.layout.width
+        animated
       );
     }
   }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
Jumping to tab far away makes bad user experience: can see a lot of empty tab scenes during animations.
![jump from 20 to 1](https://user-images.githubusercontent.com/6456056/37863050-49f76bfa-2fa3-11e8-85e3-3b55eac2ed17.gif)

### Test plan
Disable animation when jumping to tab far away.  In my MR, I set this value to 0, but I have to admit that it's better to set by user manually or something else, rather than hard code.

![jump from 20 to 1 - fixed](https://user-images.githubusercontent.com/6456056/37863051-4c4e5558-2fa3-11e8-8e0e-effe1acf1a0c.gif)

@satya164   I'm the same guy with @bournewang (I got a problem on that Github account, so I use this account temporarily)