### PR TITLE
TabViewPagerPan compatible with SafeAreaView

### DIFF
--- a/src/TabViewPagerPan.js
+++ b/src/TabViewPagerPan.js
@@ -262,7 +262,7 @@ export default class TabViewPagerPan<T: *> extends React.Component<Props<T>> {
               width
                 ? {
                     width,
-                    transform: [{ translateX }]
+                    transform: [{ translateX }],
                   }
                 : i === navigationState.index ? StyleSheet.absoluteFill : null
             }

--- a/src/TabViewPagerPan.js
+++ b/src/TabViewPagerPan.js
@@ -250,32 +250,27 @@ export default class TabViewPagerPan<T: *> extends React.Component<Props<T>> {
     });
 
     return (
-      <Animated.View
-        style={[
-          styles.sheet,
-          width
-            ? {
-                width: routes.length * width,
-                transform: [{ translateX }],
-              }
-            : null,
-        ]}
+      <View
+        style={[styles.sheet, width ? { width } : null]}
         {...this._panResponder.panHandlers}
       >
         {React.Children.map(children, (child, i) => (
-          <View
+          <Animated.View
             key={navigationState.routes[i].key}
             testID={navigationState.routes[i].testID}
             style={
               width
-                ? { width }
+                ? {
+                    width,
+                    transform: [{ translateX }]
+                  }
                 : i === navigationState.index ? StyleSheet.absoluteFill : null
             }
           >
             {i === navigationState.index || width ? child : null}
-          </View>
+          </Animated.View>
         ))}
-      </Animated.View>
+      </View>
     );
   }
 }


### PR DESCRIPTION
On iPhone X, content in a [SafeAreaView](https://facebook.github.io/react-native/docs/0.50/safeareaview.html) allows its children to avoid being under the home bar and sensor housing of iPhone X. This relies on all parent views also being bounded by the screen edges. That limitation is so that content can scroll offscreen without being clipped at the safe area edges.

In an app the team I'm on is building, we are using React-Navigation which uses React-Native-Tab-View's TabViewPagerPan for bottom-tabs on iOS. Currently, the parent of all the tabs is `number_of_tabs` times larger than the screen, and SafeAreaView is not working correctly. For example, an iPhone X in landscape would have the SafeAreaView padding in the first tab only present on the left. The final tab would be padded on the right. And all tabs between those would have no padding at all (components near the screen edge would be unreachable or cut off).

This Pull Request adjusts the parent to be the size of the screen, and its tab children are translated with the Pan gesture and tab switching. In the screenshots below, blue is where content will draw inside of a SafeAreaView.

||Left tab | Middle tab | Right Tab|
|---|---|---|---|
|*Before*|<img src="https://user-images.githubusercontent.com/6138914/37976768-86ebc402-31e2-11e8-88f0-e54261031e65.png" title="Left tab, before" width="100%"/>|<img src="https://user-images.githubusercontent.com/6138914/37976795-9657d0b6-31e2-11e8-9e4d-e112122b6ca5.png" title="Middle tab, before" width="100%"/>|<img src="https://user-images.githubusercontent.com/6138914/37977962-2fd176be-31e5-11e8-819e-6d931a33f292.png" title="Right tab, before" width="100%"/>|
|*After*|<img src="https://user-images.githubusercontent.com/6138914/37976403-b8d57018-31e1-11e8-970e-14e7e89bd1c1.png" title="Left tab, after" width="100%"/>|<img src="https://user-images.githubusercontent.com/6138914/37976504-eed6fea2-31e1-11e8-937c-1d71a1300f39.png" title="Middle tab, after" width="100%"/>|<img src="https://user-images.githubusercontent.com/6138914/37977378-e4f5083c-31e3-11e8-96b1-c53110af104f.png" title="Right tab, after" width="100%"/>|
