### PR TITLE
RTL support for TabViewPagerPan

### DIFF
--- a/src/TabViewPagerPan.js
+++ b/src/TabViewPagerPan.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import {
   Animated,
+  I18nManager,
   PanResponder,
   StyleSheet,
   View,
@@ -236,11 +237,14 @@ export default class TabViewPagerPan<T: *> extends React.Component<Props<T>> {
     const { width } = layout;
     const { routes } = navigationState;
     const maxTranslate = width * (routes.length - 1);
-    const translateX = Animated.add(panX, offsetX).interpolate({
-      inputRange: [-maxTranslate, 0],
-      outputRange: [-maxTranslate, 0],
-      extrapolate: 'clamp',
-    });
+    const translateX = Animated.multiply(
+      Animated.add(panX, offsetX).interpolate({
+        inputRange: [-maxTranslate, 0],
+        outputRange: [-maxTranslate, 0],
+        extrapolate: 'clamp',
+      }),
+      I18nManager.isRTL ? -1 : 1
+    );
 
     return (
       <Animated.View


### PR DESCRIPTION
When use Tabbar in RTL apps, first tab shown perfect and as expected but other tabs are blank and doesn't show anything.
After digging in library I found that this issue is related to transformation of View inside `TabViewPagerPan.is`  and it could solve just by inverting translate value for RTL layouts

### Test plan
- Just add tabbar with two or three tabs and use `I18nManager.forceRTL(true)` to change layout direction
