### PR TITLE
Fix danger zone from Expo

### DIFF
--- a/src/TabViewPagerExperimental.js
+++ b/src/TabViewPagerExperimental.js
@@ -30,8 +30,8 @@ export default class TabViewPagerExperimental<T: *> extends React.Component<
 
   static defaultProps = {
     GestureHandler:
-      global.__expo && global.__expo.DangerZone
-        ? global.__expo.DangerZone.GestureHandler
+      global.__expo && (global.__expo.DangerZone || global.__expo.GestureHandler)
+        ? (global.__expo.GestureHandler || global.__expo.DangerZone.GestureHandler)
         : undefined,
     canJumpToTab: () => true,
   };


### PR DESCRIPTION
### Motivation
GestureHandler is no longer on DangerZone and is causing yellow box warnings.