### PR TITLE
tabBar: Pass borderless from props to TouchableItem.

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -24,6 +24,7 @@ type IndicatorProps<T> = SceneRendererProps<T> & {
 };
 
 type Props<T> = SceneRendererProps<T> & {
+  borderless?: boolean,
   scrollEnabled?: boolean,
   bounces?: boolean,
   pressColor?: string,
@@ -454,7 +455,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
 
               return (
                 <TouchableItem
-                  borderless
+                  borderless={this.props.borderless}
                   key={route.key}
                   testID={route.testID}
                   accessible={route.accessible}


### PR DESCRIPTION
Before always true was passed.

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
We are using this and was facing issue of extended ripple effect. Because always true was passed. So pass it from the the props, giving control to the user.
![37422059-98921d98-27e0-11e8-90d2-e23636c589b4](https://user-images.githubusercontent.com/18511177/39956975-90306a14-5608-11e8-9200-f8775e6951af.png)

 

### Test plan

Pass `borderless: false,` or `borderless: true,` in the `tabBarOptions`.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->