### PR TITLE
Added `activeTabStyle` and `activeLabelStyle` option for `TabBar` component.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ renderTabBar={props =>
 - `tabStyle`: style object for the individual tabs in the tab bar.
 - `indicatorStyle`: style object for the active indicator.
 - `activeTabStyle` - style object for the individual active tab in the tab bar
+- `activeLabelStyle` - style object for the individual label in the active tab bar
 - `labelStyle`: style object for the tab item label.
 - `style`: style object for the tab bar.
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Material design themed tab bar. Can be used as both top and bottom tab bar.
 - `bounces` - whether the tab bar bounces when scrolling
 - `useNativeDriver` - whether to use native animations
 - `tabStyle` - style object for the individual tabs in the tab bar
+- `activeTabStyle` - style object for the individual active tab in the tab bar
 - `indicatorStyle` - style object for the active indicator
 - `labelStyle` - style object for the tab item label
 - `style` - style object for the tab bar

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -44,7 +44,7 @@ export default class ExampleList extends React.Component<{}, State> {
     restoring: false,
   };
 
-  componentWillMount() {
+  componentDidMount() {
     if (process.env.NODE_ENV !== 'production') {
       this._restoreNavigationState();
     }

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -192,7 +192,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
     this._adjustScroll(value);
   };
 
-  _renderLabel = (scene: Scene<*>) => {
+  _renderLabel = (scene: Scene<*>, focused: boolean) => {
     if (typeof this.props.renderLabel !== 'undefined') {
       return this.props.renderLabel(scene);
     }
@@ -205,7 +205,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
         style={[
           styles.tabLabel,
           this.props.labelStyle,
-          scene.focused ? this.props.activeLabelStyle : {},
+          focused ? this.props.activeLabelStyle : {},
         ]}
       >
         {label}
@@ -355,9 +355,14 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
   };
 
   render() {
-    const { position, navigationState, scrollEnabled, bounces, activeTabStyle } = this.props;
+    const {
+      position,
+      navigationState,
+      scrollEnabled,
+      bounces,
+      activeTabStyle,
+    } = this.props;
     const { routes } = navigationState;
-    const { routes, index } = navigationState;
     const tabWidth = this._getTabWidth(this.props);
     const tabBarWidth = tabWidth * routes.length;
 
@@ -425,7 +430,9 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
                   outputRange,
                 })
               );
-              const label = this._renderLabel({ route, focused });
+
+              const isFocused = i === navigationState.index;
+              const label = this._renderLabel({ route }, isFocused);
               const icon = this.props.renderIcon
                 ? this.props.renderIcon({ route })
                 : null;
@@ -471,8 +478,6 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
                   ? accessibilityLabel
                   : this.props.getLabelText({ route });
 
-              const isFocused = i === navigationState.index;
-
               return (
                 <TouchableItem
                   borderless
@@ -497,7 +502,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
                         tabStyle,
                         passedTabStyle,
                         styles.container,
-                        focused && activeTabStyle ? activeTabStyle : null,
+                        isFocused && activeTabStyle ? activeTabStyle : null,
                       ]}
                     >
                       {icon}

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -38,6 +38,7 @@ type Props<T> = SceneRendererProps<T> & {
   indicatorStyle?: Style,
   labelStyle?: Style,
   style?: Style,
+  activeTabStyle?: Style,
 };
 
 type State = {|
@@ -62,6 +63,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
     onTabPress: PropTypes.func,
     labelStyle: PropTypes.any,
     style: PropTypes.any,
+    activeTabStyle: PropTypes.any,
   };
 
   static defaultProps = {
@@ -335,7 +337,13 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
     (this._scrollView = el && el._component);
 
   render() {
-    const { position, navigationState, scrollEnabled, bounces } = this.props;
+    const {
+      position,
+      navigationState,
+      scrollEnabled,
+      bounces,
+      activeTabStyle,
+    } = this.props;
     const { routes, index } = navigationState;
     const tabWidth = this._getTabWidth(this.props);
     const tabBarWidth = tabWidth * routes.length;
@@ -471,6 +479,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
                         tabStyle,
                         passedTabStyle,
                         styles.container,
+                        focused && activeTabStyle ? activeTabStyle : null,
                       ]}
                     >
                       {icon}

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -189,7 +189,13 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
       return null;
     }
     return (
-      <Animated.Text style={[styles.tabLabel, this.props.labelStyle, focused ? this.props.activeLabelStyle : {}]}>
+      <Animated.Text
+        style={[
+          styles.tabLabel,
+          this.props.labelStyle,
+          focused ? this.props.activeLabelStyle : {},
+        ]}
+      >
         {label}
       </Animated.Text>
     );

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -35,11 +35,11 @@ type Props<T> = SceneRendererProps<T> & {
   renderIndicator?: (props: IndicatorProps<T>) => ?React.Element<any>,
   onTabPress?: (scene: Scene<T>) => mixed,
   tabStyle?: Style,
+  activeTabStyle?: Style,
   indicatorStyle?: Style,
   labelStyle?: Style,
   activeLabelStyle?: Style,
   style?: Style,
-  activeTabStyle?: Style,
 };
 
 type State = {|

--- a/src/TabViewPagerPan.js
+++ b/src/TabViewPagerPan.js
@@ -67,23 +67,6 @@ export default class TabViewPagerPan<T: *> extends React.Component<Props<T>> {
     },
   };
 
-  constructor(props: Props<T>) {
-    super(props);
-    this._currentIndex = this.props.navigationState.index;
-  }
-
-  componentWillMount() {
-    this._panResponder = PanResponder.create({
-      onMoveShouldSetPanResponder: this._canMoveScreen,
-      onMoveShouldSetPanResponderCapture: this._canMoveScreen,
-      onPanResponderGrant: this._startGesture,
-      onPanResponderMove: this._respondToGesture,
-      onPanResponderTerminate: this._finishGesture,
-      onPanResponderRelease: this._finishGesture,
-      onPanResponderTerminationRequest: () => true,
-    });
-  }
-
   componentDidUpdate(prevProps: Props<T>) {
     this._currentIndex = this.props.navigationState.index;
 
@@ -99,7 +82,8 @@ export default class TabViewPagerPan<T: *> extends React.Component<Props<T>> {
     }
   }
 
-  _currentIndex: number;
+  _currentIndex = this.props.navigationState.index;
+  _pendingIndex: ?number;
 
   _isMovingHorizontally = (evt: GestureEvent, gestureState: GestureState) => {
     return (
@@ -228,8 +212,15 @@ export default class TabViewPagerPan<T: *> extends React.Component<Props<T>> {
     this._pendingIndex = index;
   };
 
-  _panResponder: any;
-  _pendingIndex: ?number;
+  _panResponder = PanResponder.create({
+    onMoveShouldSetPanResponder: this._canMoveScreen,
+    onMoveShouldSetPanResponderCapture: this._canMoveScreen,
+    onPanResponderGrant: this._startGesture,
+    onPanResponderMove: this._respondToGesture,
+    onPanResponderTerminate: this._finishGesture,
+    onPanResponderRelease: this._finishGesture,
+    onPanResponderTerminationRequest: () => true,
+  });
 
   render() {
     const { panX, offsetX, navigationState, layout, children } = this.props;


### PR DESCRIPTION
### Motivation

As of today, there is no way to pass styles that indicate active label in TabBar and also for active tab bar item. I have added option to pass `activeTabStyle` and also `activeLabelStyle` (thanks for @	lpotapczuk - merged his PR with `activeLabelStyle` and fixed eslint to pass eslint and flow checks)

### Test plan

Pass `activeTabStyle` and `activeLabelStyle` to `TabBar` component in `_renderHeader` function to modify style on active element.
