### PR TITLE
feat: add the ability to override pager container style

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Container component responsible for managing tab transitions.
 - `renderFooter` - optional callback which returns a react element to use as bottom tab bar
 - `renderPager` - optional callback which returns a react element to handle swipe gesture and animation
 - `renderScene` - callback which returns a react element to use as a scene
+- `pagerStyle` - optional style object for the pager container
 
 Any other props are passed to the underlying pager.
 

--- a/src/TabViewAnimated.js
+++ b/src/TabViewAnimated.js
@@ -2,7 +2,13 @@
 
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { Animated, Platform, View, StyleSheet } from 'react-native';
+import {
+  Animated,
+  Platform,
+  View,
+  StyleSheet,
+  ViewPropTypes,
+} from 'react-native';
 import { NavigationStatePropType } from './TabViewPropTypes';
 import type {
   Scene,
@@ -27,6 +33,7 @@ type Props<T> = PagerCommonProps<T> &
     renderFooter?: (props: SceneRendererProps<T>) => ?React.Element<any>,
     useNativeDriver?: boolean,
     style?: Style,
+    pagerStyle?: Style,
   };
 
 type State = {|
@@ -67,6 +74,7 @@ export default class TabViewAnimated<T: *> extends React.Component<
     renderScene: PropTypes.func.isRequired,
     renderHeader: PropTypes.func,
     renderFooter: PropTypes.func,
+    pagerStyle: ViewPropTypes.style,
   };
 
   static defaultProps = {
@@ -208,7 +216,10 @@ export default class TabViewAnimated<T: *> extends React.Component<
     return (
       <View collapsable={false} style={[styles.container, this.props.style]}>
         {renderHeader && renderHeader(props)}
-        <View onLayout={this._handleLayout} style={styles.pager}>
+        <View
+          onLayout={this._handleLayout}
+          style={[styles.pager, this.props.pagerStyle]}
+        >
           {renderPager({
             ...props,
             ...rest,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
One specific use case for this is implementing variable tab height support. Default
`pager: { flex: 1 }` style interferes with it; this change gives us a way to override it.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

This is a minimal change that does not change current behavior of the component. It does introduce another point of customization for something that wasn't customizable, but since similar existing points of customization are not being automatically tested, I did not extend the test suite to cover this functionality.