### PR TITLE
fix: missing react import

### DIFF
--- a/src/TypeDefinitions.js
+++ b/src/TypeDefinitions.js
@@ -2,6 +2,7 @@
 
 import { Animated } from 'react-native';
 import type { Node } from 'react';
+import * as React from 'react';
 
 export type Route<T: { key: string }> = $Exact<T>;
 

--- a/src/TypeDefinitions.js
+++ b/src/TypeDefinitions.js
@@ -1,8 +1,8 @@
 /* @flow */
 
+import * as React from 'react';
 import { Animated } from 'react-native';
 import type { Node } from 'react';
-import * as React from 'react';
 
 export type Route<T: { key: string }> = $Exact<T>;
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
After migration to new version, I found missing import in `TypeDefinitions.js` :

![screen shot 2018-06-05 at 09 42 15](https://user-images.githubusercontent.com/10349378/40962070-cc8b6582-68a4-11e8-808d-5cea1b6b50ae.png)

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
