### PR TITLE
Allow to customise indicator baseline view

### DIFF
--- a/example/src/TopBarTextExample.js
+++ b/example/src/TopBarTextExample.js
@@ -51,6 +51,7 @@ export default class TopBarTextExample extends React.Component<*, State> {
       {...props}
       scrollEnabled
       indicatorStyle={styles.indicator}
+      indicatorBaseLineViewStyle={styles.indicatorBaseLineView}
       style={styles.tabbar}
       tabStyle={styles.tab}
       labelStyle={styles.label}
@@ -90,6 +91,9 @@ const styles = StyleSheet.create({
   },
   indicator: {
     backgroundColor: '#ffeb3b',
+  },
+  indicatorBaseLineView: {
+    backgroundColor: '#E91F63',
   },
   label: {
     color: '#fff',

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -39,7 +39,7 @@ type Props<T> = SceneRendererProps<T> & {
   onTabPress?: (scene: Scene<T>) => mixed,
   tabStyle?: ViewStyleProp,
   indicatorStyle?: ViewStyleProp,
-  indicatorBaseLineViewStyle?: Style,
+  indicatorBaseLineViewStyle?: ViewStyleProp,
   labelStyle?: TextStyleProp,
   style?: ViewStyleProp,
 };
@@ -346,7 +346,13 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
   };
 
   render() {
-    const { position, navigationState, scrollEnabled, bounces } = this.props;
+    const {
+      indicatorBaseLineViewStyle,
+      position,
+      navigationState,
+      scrollEnabled,
+      bounces,
+    } = this.props;
     const { routes } = navigationState;
     const tabWidth = this._getTabWidth(this.props);
     const tabBarWidth = tabWidth * routes.length;
@@ -366,7 +372,9 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
               : null,
           ]}
         >
-          <View style={[styles.indicator, this.props.indicatorBaseLineViewStyle]}></View>
+          {indicatorBaseLineViewStyle && (
+            <View style={[styles.indicator, indicatorBaseLineViewStyle]} />
+          )}
           {this._renderIndicator({
             ...this.props,
             width: tabWidth,

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -39,6 +39,7 @@ type Props<T> = SceneRendererProps<T> & {
   onTabPress?: (scene: Scene<T>) => mixed,
   tabStyle?: ViewStyleProp,
   indicatorStyle?: ViewStyleProp,
+  indicatorBaseLineViewStyle?: Style,
   labelStyle?: TextStyleProp,
   style?: ViewStyleProp,
 };
@@ -365,6 +366,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
               : null,
           ]}
         >
+          <View style={[styles.indicator, this.props.indicatorBaseLineViewStyle]}></View>
           {this._renderIndicator({
             ...this.props,
             width: tabWidth,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
This PR is to provide a way to optionally customise indicator baseline view, as shown below
<img width="385" alt="image" src="https://user-images.githubusercontent.com/2090084/42140140-e3583dd2-7ddd-11e8-9994-ad12787a5ef6.png">


### Test plan
Finish following test:
1. yarn test
2. yarn lint
3. yarn flow
4. add a demo in TopBarTextExample