### PR TITLE
Add optional bounces property on ScrollView

### DIFF
--- a/example/src/TopBarTextExample.js
+++ b/example/src/TopBarTextExample.js
@@ -73,6 +73,7 @@ export default class TopBarTextExample extends React.Component<*, State> {
         renderTabBar={this._renderTabBar}
         onIndexChange={this._handleIndexChange}
         initialLayout={initialLayout}
+        bounces
       />
     );
   }

--- a/src/PagerScroll.js
+++ b/src/PagerScroll.js
@@ -135,6 +135,7 @@ export default class PagerScroll<T: *> extends React.Component<
 
   render() {
     const {
+      bounces,
       children,
       layout,
       navigationState,
@@ -152,7 +153,7 @@ export default class PagerScroll<T: *> extends React.Component<
         overScrollMode="never"
         scrollEnabled={this.props.swipeEnabled}
         automaticallyAdjustContentInsets={false}
-        bounces={false}
+        bounces={bounces}
         alwaysBounceHorizontal={false}
         scrollsToTop={false}
         showsHorizontalScrollIndicator={false}

--- a/src/TabView.js
+++ b/src/TabView.js
@@ -26,6 +26,7 @@ type Props<T> = PagerCommonProps<T> &
     renderTabBar: (props: SceneRendererProps<T>) => React.Node,
     tabBarPosition: 'top' | 'bottom',
     useNativeDriver?: boolean,
+    bounces?: boolean,
     style?: ViewStyleProp,
   };
 
@@ -63,6 +64,7 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
       height: 0,
       width: 0,
     },
+    bounces: false,
     useNativeDriver: false,
   };
 
@@ -144,6 +146,7 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
     navigationState: this.props.navigationState,
     jumpTo: this._jumpTo,
     useNativeDriver: this.props.useNativeDriver === true,
+    bounces: this.props.bounces,
   });
 
   _jumpTo = (key: string) => {

--- a/src/TypeDefinitions.js
+++ b/src/TypeDefinitions.js
@@ -40,6 +40,7 @@ export type PagerRendererProps<T> = PagerCommonProps<T> & {
   offsetX: Animated.Value,
   jumpTo: (key: string) => mixed,
   useNativeDriver: boolean,
+  bounces?: boolean,
   children: Node,
 };
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
It's a natural to have bounces animation in iOS/Android scroll view.
This PR adds an optional property of bounces. By default, it's false.

![animation](https://user-images.githubusercontent.com/2090084/42143670-b6b0954c-7df9-11e8-9d4d-9318d882c666.gif)


### Test plan

1. yarn run lint
2. yarn run flow
3. yarn run test
