### PR TITLE
Selected tab bar indicator jumps to wrong positions  when tab bar is scrollable

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -136,6 +136,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
     } else if (prevProps.navigationState.index !== pendingIndex) {
       this._resetScroll(this.props.navigationState.index);
     }
+    this._handlePosition();
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
Everything is perfect if scene rendering is not expensive.  However, it comes a problem if that's expensive rendering, especially on old devices like iPhone5/5s and together with `ListView/FlatList`. I guess the root cause is expensive rendering could make `_renderIndicator transform` limp because of single js thread.

![problem](https://user-images.githubusercontent.com/2090084/42270931-62204d7e-7fc5-11e8-86bc-fa3380da1a75.gif)


<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
This PR is to resolve a problem: selected tab bar indicator could goes to wrong positions.

### Test plan
Verified on old iPhone5 and new iPhoneX device

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->