### PR TITLE
Add support for RTL in TabView

### DIFF
--- a/src/TabView.js
+++ b/src/TabView.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { Animated, View, StyleSheet } from 'react-native';
+import { Animated, View, StyleSheet, I18nManager } from 'react-native';
 import TabBar from './TabBar';
 import PagerDefault from './PagerDefault';
 import { NavigationStatePropType } from './PropTypes';
@@ -82,9 +82,11 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
       x: layout.width || 0.001,
       y: layout.height || 0.001,
     });
-    const position = Animated.multiply(
-      Animated.divide(Animated.add(panX, offsetX), layoutXY.x),
-      -1
+    const position = Animated.add(
+      Animated.multiply(
+        Animated.divide(Animated.add(panX, offsetX), layoutXY.x),
+        -1),
+      I18nManager.isRTL? navigationState.routes.length - 1 : 0
     );
 
     this.state = {
@@ -121,7 +123,7 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
       return;
     }
 
-    this.state.offsetX.setValue(-this.props.navigationState.index * width);
+    this.state.offsetX.setValue((I18nManager.isRTL? this.props.navigationState.routes.length - 1 - this.props.navigationState.index : -this.props.navigationState.index) * width);
     this.state.layoutXY.setValue({
       // This is hacky, but we need to make sure that the value is never 0
       x: width || 0.001,

--- a/src/TabView.js
+++ b/src/TabView.js
@@ -126,7 +126,11 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
 
     this.state.offsetX.setValue(
       (I18nManager.isRTL
-        ? this.props.navigationState.routes.length - 1 - this.props.navigationState.index : -this.props.navigationState.index) * width);
+        ? this.props.navigationState.routes.length - 
+          1 - 
+          this.props.navigationState.index
+        : -this.props.navigationState.index) * width
+      );
     this.state.layoutXY.setValue({
       // This is hacky, but we need to make sure that the value is never 0
       x: width || 0.001,

--- a/src/TabView.js
+++ b/src/TabView.js
@@ -126,11 +126,11 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
 
     this.state.offsetX.setValue(
       (I18nManager.isRTL
-        ? this.props.navigationState.routes.length - 
-          1 - 
+        ? this.props.navigationState.routes.length -
+          1 -
           this.props.navigationState.index
         : -this.props.navigationState.index) * width
-      );
+    );
     this.state.layoutXY.setValue({
       // This is hacky, but we need to make sure that the value is never 0
       x: width || 0.001,

--- a/src/TabView.js
+++ b/src/TabView.js
@@ -85,8 +85,9 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
     const position = Animated.add(
       Animated.multiply(
         Animated.divide(Animated.add(panX, offsetX), layoutXY.x),
-        -1),
-      I18nManager.isRTL? navigationState.routes.length - 1 : 0
+        -1
+      ),
+      I18nManager.isRTL ? navigationState.routes.length - 1 : 0
     );
 
     this.state = {
@@ -123,7 +124,9 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
       return;
     }
 
-    this.state.offsetX.setValue((I18nManager.isRTL? this.props.navigationState.routes.length - 1 - this.props.navigationState.index : -this.props.navigationState.index) * width);
+    this.state.offsetX.setValue(
+      (I18nManager.isRTL
+        ? this.props.navigationState.routes.length - 1 - this.props.navigationState.index : -this.props.navigationState.index) * width);
     this.state.layoutXY.setValue({
       // This is hacky, but we need to make sure that the value is never 0
       x: width || 0.001,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

This pull requests adds support for RTL problems described in the following issue: https://github.com/react-native-community/react-native-tab-view/issues/184

Animations, indicator and focus are off when in RTL. Notice the indicator doesn't change when moving between tabs and label focus is off as well.

![ezgif-1-a66b111ea4](https://user-images.githubusercontent.com/1557675/42400076-3c483c68-813e-11e8-8916-1f5a115ab348.gif)

The culprit for most issues seems to be in calculating the position in `TabView`.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
* Test on RTL configured device (e.g. Hebrew)
* Use Android's Developer Options -> Force RTL
* Add code in the app: `I18nManager.forceRTL(true)`

I used the following `App.js` as well as my own app to test:
```
import * as React from 'react';
import { View, StyleSheet, Dimensions, Text, I18nManager } from 'react-native';
import { TabView, TabBar, SceneMap } from 'react-native-tab-view';

// I18nManager.allowRTL(true);
// I18nManager.forceRTL(true);
const FirstRoute = () => (
    <View style={[{ backgroundColor: '#ff4081', height: "100%" }]}>
        <Text>One</Text>
    </View>
);
const SecondRoute = () => (
    <View style={[{ backgroundColor: '#673ab7', height: "100%" }]}>
        <Text>Two</Text>
    </View>
);
const ThirdRoute = () => (
    <View style={[{ backgroundColor: '#67EEb7', height: "100%" }]}>
        <Text>Three</Text>
    </View>
);

export default class TabViewExample extends React.Component {
    state = {
        index: 0,
        routes: [
            { key: 'first', title: 'First' },
            { key: 'second', title: 'Second' },
            { key: 'third', title: 'Third' },
        ],
    };

    render() {
        return (
            <TabView
                navigationState={this.state}
                renderScene={SceneMap({
                    first: FirstRoute,
                    second: SecondRoute,
                    third: ThirdRoute
                })}
                onIndexChange={index => this.setState({ index })}
                initialLayout={{ width: Dimensions.get('window').width, height: 40 }}
            />
        );
    }
}
```