### PR TITLE
Add onTabLongPress handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ renderTabBar={props =>
 - `renderIndicator`: callback which returns a custom React Element to be used as a tab indicator.
 - `renderBadge`: callback which returns a custom React Element to be used as a badge.
 - `onTabPress`: callback invoked on tab press, useful for things like scroll to top.
+- `onTabLongPress`: callback invoked on tab long-press, for example to show a drawer with more options.
 - `pressColor`: color for material ripple (Android >= 5.0 only).
 - `pressOpacity`: opacity for pressed tab (iOS and Android < 5.0 only).
 - `scrollEnabled`: whether to enable scrollable tabs.

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -37,6 +37,7 @@ type Props<T> = SceneRendererProps<T> & {
   renderBadge?: (scene: Scene<T>) => React.Node,
   renderIndicator?: (props: IndicatorProps<T>) => React.Node,
   onTabPress?: (scene: Scene<T>) => mixed,
+  onTabLongPress?: (scene: Scene<T>) => mixed,
   tabStyle?: ViewStyleProp,
   indicatorStyle?: ViewStyleProp,
   labelStyle?: TextStyleProp,
@@ -66,6 +67,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
     renderLabel: PropTypes.func,
     renderIndicator: PropTypes.func,
     onTabPress: PropTypes.func,
+    onTabLongPress: PropTypes.func,
     labelStyle: PropTypes.any,
     style: PropTypes.any,
   };
@@ -263,6 +265,12 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
     }
 
     this.props.jumpTo(route.key);
+  };
+
+  _handleTabLongPress = ({ route }: Scene<*>) => {
+    if (this.props.onTabLongPress) {
+      this.props.onTabLongPress({ route });
+    }
   };
 
   _normalizeScrollValue = (props, value) => {
@@ -477,6 +485,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
                   pressOpacity={this.props.pressOpacity}
                   delayPressIn={0}
                   onPress={() => this._handleTabPress({ route })}
+                  onLongPress={() => this._handleTabLongPress({ route })}
                   style={tabContainerStyle}
                 >
                   <View pointerEvents="none" style={styles.container}>


### PR DESCRIPTION
This PR enables a `onTabLongPress` handler.

If merged, I will also send PRs to `react-navigation-tabs` and `react-navigation`.
Please see my `react-navigation` RFC to understand my motivation: https://github.com/react-navigation/rfcs/pull/55