### PR TITLE
Fixes issue #468

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -142,14 +142,8 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
 
   _resetState = () => {
     this.props.scrollEnabled && this._stopTrackingPosition();
-    this.setState(
-      {
-        scrollAmount: new Animated.Value(0),
-      },
-      () => {
-        this.props.scrollEnabled && this._startTrackingPosition();
-      }
-    );
+    this.state.scrollAmount.setValue(0);
+    this.props.scrollEnabled && this._startTrackingPosition();
   };
 
   _startTrackingPosition = () => {


### PR DESCRIPTION
### Motivation

This PR fixes the issues discussed in #468 as well as a secondary issue where the indicator will not render correctly if the tab width is large and the initial index requires a scroll.  For example, in the `TopBarTextExample.js` file if you change the state to `index: 2` and then the style to `tab: { width: 320 }` you can see this second problem.

The initially reported problem is resolved by a new `resetScroll` function which is called with width is changed.  The secondary issue is actually resolved by removing the `initialOffset` state - I am not entirely sure why this was messing that up nor am I am sure why the initial offset is needed at all since all the examples still work as desired without it.

### Test plan

Run the examples, change orientation, see the indicator stick with the selected tab.

NOTE: the tab layout can still be slightly off after an orientation change, but at least now the indicator and the tabs are offset together.