### PR TITLE
Fix onSwipeStart for PagerExperimental

### DIFF
--- a/src/PagerExperimental.js
+++ b/src/PagerExperimental.js
@@ -48,7 +48,7 @@ export default class PagerExperimental<T: *> extends React.Component<Props<T>> {
   _handleHandlerStateChange = event => {
     const { GestureHandler } = this.props;
 
-    if (event.nativeEvent.state === GestureHandler.State.BEGIN) {
+    if (event.nativeEvent.state === GestureHandler.State.BEGAN) {
       this.props.onSwipeStart && this.props.onSwipeStart();
     } else if (event.nativeEvent.state === GestureHandler.State.END) {
       this.props.onSwipeEnd && this.props.onSwipeEnd();


### PR DESCRIPTION
Right now, `onSwipeStart` never fires, and it's because there is a misspelling of GestureHandler's state as `BEGIN` when it should be `BEGAN`:
https://github.com/kmagiera/react-native-gesture-handler/blob/master/docs/state.md#began
