### PR TITLE
hides offsecreen views from keyboard accessibility on the web

### DIFF
--- a/src/PagerPan.js
+++ b/src/PagerPan.js
@@ -6,9 +6,9 @@ import {
   Animated,
   I18nManager,
   PanResponder,
+  Platform,
   StyleSheet,
   View,
-  Platform,
 } from 'react-native';
 import { PagerRendererPropType } from './PropTypes';
 import type { PagerRendererProps } from './TypeDefinitions';
@@ -243,6 +243,7 @@ export default class PagerPan<T: *> extends React.Component<Props<T>> {
       }),
       I18nManager.isRTL ? -1 : 1
     );
+    const onWeb = Platform.OS === 'web';
 
     return (
       <Animated.View
@@ -265,9 +266,10 @@ export default class PagerPan<T: *> extends React.Component<Props<T>> {
             <View
               key={route.key}
               testID={this.props.getTestID({ route })}
-              style={
-                width ? { width } : focused ? StyleSheet.absoluteFill : null
-              }
+              style={[
+                width ? { width } : focused ? StyleSheet.absoluteFill : null,
+                onWeb && !focused ? { visibility: 'hidden' } : null,
+              ]}
             >
               {focused || width ? child : null}
             </View>


### PR DESCRIPTION
### Motivation

When using react-native-tab-view in conjunction with react-native-web, it is important for accessibility to hide the content in the pager that is offscreen from keyboard navigation.  This can be accomplished with a simple CSS style `visibility: 'hidden'`.  This PR adds that only when a scene is not focused and only when the Platform is Web

### Test plan

Run your app in the web, ensure elements off screen are not keyboard accessible.
