### PR TITLE
[Android] Fix usage of PagerExperimental with 1 route and with useNativeDriver

### DIFF
--- a/src/PagerExperimental.js
+++ b/src/PagerExperimental.js
@@ -153,11 +153,14 @@ export default class PagerExperimental<T: *> extends React.Component<Props<T>> {
     const { width } = layout;
     const { routes } = navigationState;
     const maxTranslate = width * (routes.length - 1);
-    const translateX = Animated.add(panX, offsetX).interpolate({
-      inputRange: [-maxTranslate, 0],
-      outputRange: [-maxTranslate, 0],
-      extrapolate: 'clamp',
-    });
+    const translateX =
+      routes.length > 1
+        ? Animated.add(panX, offsetX).interpolate({
+            inputRange: [-maxTranslate, 0],
+            outputRange: [-maxTranslate, 0],
+            extrapolate: 'clamp',
+          })
+        : 0;
 
     return (
       <GestureHandler.PanGestureHandler


### PR DESCRIPTION
### Motivation

If `PagerExperimental` is used on Android with 1 route and with `useNativeDriver` flag, then it doesn't render anything. Turned out that's because with 1 route `maxTranslate` calculates to `0`, and interpolation becomes
```
Animated.add(panX, offsetX).interpolate({
  inputRange: [-0, 0],
  outputRange: [-0, 0],
  extrapolate: 'clamp',
});
```
which doesn't work well with `useNativeDriver` (strangely enough, if one disables `useNativeDriver`, it works as expected).

Because in case with 1 route this calculates to non-changing animated `0` anyway, I've made this fix.

### Test plan

Use `PagerExperimental` on Android with 1 route and `useNativeDriver`. See that it renders content with my fix and doesn't render without it.