### PR TITLE
Add support for RTL in TabView

### DIFF
--- a/src/PagerAndroid.js
+++ b/src/PagerAndroid.js
@@ -120,15 +120,11 @@ export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
 
   render() {
     const { navigationState, swipeEnabled, keyboardDismissMode } = this.props;
-    let children = [];
-    React.Children.forEach(this.props.children, c => {
-      if (I18nManager.isRTL) {
-        children = [c, ...children];
-      } else {
-        children = [...children, c];
-      }
-    });
-    const content = React.Children.map(children, (child, i) => {
+    const children = I18nManager.isRTL
+    ? React.Children.toArray(this.props.children).reverse()
+    : React.Children.toArray(this.props.children);
+    
+    const content = children.map((child, i) => {
       const route = navigationState.routes[i];
       const focused = i === navigationState.index;
 

--- a/src/PagerAndroid.js
+++ b/src/PagerAndroid.js
@@ -33,8 +33,7 @@ export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
 
   componentDidUpdate(prevProps: Props<T>) {
     if (
-      prevProps.navigationState.routes.length !==
-        this.props.navigationState.routes.length ||
+      prevProps.navigationState.routes !== this.props.navigationState.routes ||
       prevProps.layout.width !== this.props.layout.width
     ) {
       this._handlePageChange(this.props.navigationState.index, false);
@@ -78,13 +77,12 @@ export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
 
   _handlePageScroll = (e: PageScrollEvent) => {
     this.props.offsetX.setValue(
-      e.nativeEvent.position *
-        this.props.layout.width *
-        (I18nManager.isRTL ? 1 : -1)
+      this._getPageIndex(e.nativeEvent.position) *
+        this.props.layout.width * -1
     );
     this.props.panX.setValue(
       e.nativeEvent.offset *
-        this.props.layout.width *
+        this.props.layout.width * 
         (I18nManager.isRTL ? 1 : -1)
     );
   };
@@ -123,11 +121,13 @@ export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
 
   render() {
     const {
-      children,
       navigationState,
       swipeEnabled,
       keyboardDismissMode,
     } = this.props;
+    const children = I18nManager.isRTL 
+      ? [...this.props.children].reverse()
+      : this.props.children
     const content = React.Children.map(children, (child, i) => {
       const route = navigationState.routes[i];
       const focused = i === navigationState.index;
@@ -144,10 +144,6 @@ export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
         </View>
       );
     });
-
-    if (I18nManager.isRTL) {
-      content.reverse();
-    }
 
     const initialPage = this._getPageIndex(navigationState.index);
 

--- a/src/PagerAndroid.js
+++ b/src/PagerAndroid.js
@@ -123,7 +123,7 @@ export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
     let children = [];
     React.Children.forEach(this.props.children, c => {
       if (I18nManager.isRTL) {
-        children = [c ,...children];
+        children = [c, ...children];
       } else {
         children = [...children, c];
       }

--- a/src/PagerAndroid.js
+++ b/src/PagerAndroid.js
@@ -120,9 +120,14 @@ export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
 
   render() {
     const { navigationState, swipeEnabled, keyboardDismissMode } = this.props;
-    const children = I18nManager.isRTL
-      ? this.props.children.slice().reverse()
-      : this.props.children;
+    let children = [];
+    React.Children.forEach(this.props.children, c => {
+      if (I18nManager.isRTL) {
+        children = [c ,...children];
+      } else {
+        children = [...children, c];
+      }
+    });
     const content = React.Children.map(children, (child, i) => {
       const route = navigationState.routes[i];
       const focused = i === navigationState.index;

--- a/src/PagerAndroid.js
+++ b/src/PagerAndroid.js
@@ -122,7 +122,7 @@ export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
     const { navigationState, swipeEnabled, keyboardDismissMode } = this.props;
     const children = I18nManager.isRTL
       ? this.props.children.slice().reverse()
-      : this.props.children
+      : this.props.children;
     const content = React.Children.map(children, (child, i) => {
       const route = navigationState.routes[i];
       const focused = i === navigationState.index;

--- a/src/PagerAndroid.js
+++ b/src/PagerAndroid.js
@@ -121,9 +121,9 @@ export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
   render() {
     const { navigationState, swipeEnabled, keyboardDismissMode } = this.props;
     const children = I18nManager.isRTL
-    ? React.Children.toArray(this.props.children).reverse()
-    : React.Children.toArray(this.props.children);
-    
+      ? React.Children.toArray(this.props.children).reverse()
+      : React.Children.toArray(this.props.children);
+
     const content = children.map((child, i) => {
       const route = navigationState.routes[i];
       const focused = i === navigationState.index;

--- a/src/PagerAndroid.js
+++ b/src/PagerAndroid.js
@@ -77,12 +77,11 @@ export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
 
   _handlePageScroll = (e: PageScrollEvent) => {
     this.props.offsetX.setValue(
-      this._getPageIndex(e.nativeEvent.position) *
-        this.props.layout.width * -1
+      this._getPageIndex(e.nativeEvent.position) * this.props.layout.width * -1
     );
     this.props.panX.setValue(
       e.nativeEvent.offset *
-        this.props.layout.width * 
+        this.props.layout.width *
         (I18nManager.isRTL ? 1 : -1)
     );
   };
@@ -120,14 +119,10 @@ export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
   };
 
   render() {
-    const {
-      navigationState,
-      swipeEnabled,
-      keyboardDismissMode,
-    } = this.props;
-    const children = I18nManager.isRTL 
+    const { navigationState, swipeEnabled, keyboardDismissMode } = this.props;
+    const children = I18nManager.isRTL
       ? [...this.props.children].reverse()
-      : this.props.children
+      : this.props.children;
     const content = React.Children.map(children, (child, i) => {
       const route = navigationState.routes[i];
       const focused = i === navigationState.index;

--- a/src/PagerAndroid.js
+++ b/src/PagerAndroid.js
@@ -121,8 +121,8 @@ export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
   render() {
     const { navigationState, swipeEnabled, keyboardDismissMode } = this.props;
     const children = I18nManager.isRTL
-      ? [...this.props.children].reverse()
-      : this.props.children;
+      ? this.props.children.slice().reverse()
+      : this.props.children
     const content = React.Children.map(children, (child, i) => {
       const route = navigationState.routes[i];
       const focused = i === navigationState.index;

--- a/src/TabView.js
+++ b/src/TabView.js
@@ -90,11 +90,12 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
     });
     const position = Animated.add(
       Animated.multiply(
-      Animated.divide(Animated.add(panX, offsetX), layoutXY.x),
+        Animated.divide(Animated.add(panX, offsetX), layoutXY.x),
         -1
       ),
       I18nManager.isRTL && Platform.OS !== 'ios'
-      ? navigationState.routes.length - 1 : 0
+      ? navigationState.routes.length - 1
+       : 0
     );
 
     this.state = {
@@ -133,8 +134,7 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
     const { navigationState } = this.props;
     this.state.offsetX.setValue(
       (I18nManager.isRTL && Platform.OS !== 'ios'
-        ? navigationState.routes.length - 1
-        - navigationState.index
+        ? navigationState.routes.length - 1 - navigationState.index
         : -navigationState.index) * width
     );
     this.state.layoutXY.setValue({

--- a/src/TabView.js
+++ b/src/TabView.js
@@ -90,7 +90,7 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
     });
     const position = Animated.add(
       Animated.multiply(
-      Animated.divide(Animated.add(panX,offsetX), layoutXY.x),
+      Animated.divide(Animated.add(panX, offsetX), layoutXY.x),
         -1
       ),
       I18nManager.isRTL && Platform.OS !== 'ios'
@@ -133,8 +133,9 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
     const { navigationState } = this.props;
     this.state.offsetX.setValue(
       (I18nManager.isRTL && Platform.OS !== 'ios'
-      ? navigationState.routes.length - 1 - navigationState.index
-      : -navigationState.index) * width
+        ? navigationState.routes.length - 1
+        - navigationState.index
+        : -navigationState.index) * width
     );
     this.state.layoutXY.setValue({
       // This is hacky, but we need to make sure that the value is never 0

--- a/src/TabView.js
+++ b/src/TabView.js
@@ -2,13 +2,7 @@
 
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import {
-  Animated,
-  View,
-  StyleSheet,
-  I18nManager,
-  Platform,
-} from 'react-native';
+import { Animated, View, StyleSheet } from 'react-native';
 import TabBar from './TabBar';
 import PagerDefault from './PagerDefault';
 import { NavigationStatePropType } from './PropTypes';
@@ -88,14 +82,9 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
       x: layout.width || 0.001,
       y: layout.height || 0.001,
     });
-    const position = Animated.add(
-      Animated.multiply(
-        Animated.divide(Animated.add(panX, offsetX), layoutXY.x),
-        -1
-      ),
-      I18nManager.isRTL && Platform.OS !== 'ios'
-        ? navigationState.routes.length - 1
-        : 0
+    const position = Animated.multiply(
+      Animated.divide(Animated.add(panX, offsetX), layoutXY.x),
+      -1
     );
 
     this.state = {
@@ -131,12 +120,8 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
     ) {
       return;
     }
-    const { navigationState } = this.props;
-    this.state.offsetX.setValue(
-      (I18nManager.isRTL && Platform.OS !== 'ios'
-        ? navigationState.routes.length - 1 - navigationState.index
-        : -navigationState.index) * width
-    );
+
+    this.state.offsetX.setValue(-this.props.navigationState.index * width);
     this.state.layoutXY.setValue({
       // This is hacky, but we need to make sure that the value is never 0
       x: width || 0.001,

--- a/src/TabView.js
+++ b/src/TabView.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { Animated, View, StyleSheet } from 'react-native';
+import { Animated, View, StyleSheet, I18nManager, Platform } from 'react-native';
 import TabBar from './TabBar';
 import PagerDefault from './PagerDefault';
 import { NavigationStatePropType } from './PropTypes';
@@ -82,9 +82,11 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
       x: layout.width || 0.001,
       y: layout.height || 0.001,
     });
-    const position = Animated.multiply(
-      Animated.divide(Animated.add(panX, offsetX), layoutXY.x),
-      -1
+    const position = Animated.add(
+      Animated.multiply(
+        Animated.divide(Animated.add(panX, offsetX), layoutXY.x),
+        -1),
+      I18nManager.isRTL && Platform.OS !== 'ios' ? navigationState.routes.length - 1 : 0
     );
 
     this.state = {
@@ -121,7 +123,7 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
       return;
     }
 
-    this.state.offsetX.setValue(-this.props.navigationState.index * width);
+    this.state.offsetX.setValue((I18nManager.isRTL && Platform.OS !== 'ios'? this.props.navigationState.routes.length - 1 - this.props.navigationState.index : -this.props.navigationState.index) * width);
     this.state.layoutXY.setValue({
       // This is hacky, but we need to make sure that the value is never 0
       x: width || 0.001,

--- a/src/TabView.js
+++ b/src/TabView.js
@@ -91,8 +91,8 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
     const position = Animated.add(
       Animated.multiply(
         Animated.divide(Animated.add(panX,offsetX),layoutXY.x),-1),
-        I18nManager.isRTL && Platform.OS !== 'ios' ?
-          navigationState.routes.length - 1 : 0
+        I18nManager.isRTL && Platform.OS !== 'ios' 
+        ? navigationState.routes.length - 1 : 0
     );
 
     this.state = {
@@ -131,7 +131,8 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
     const { navigationState } = this.props;
     this.state.offsetX.setValue((I18nManager.isRTL && Platform.OS !== 'ios' ?
       navigationState.routes.length - 1 - navigationState.index
-      : -navigationState.index) * width);
+      : -navigationState.index) * width
+    );
     this.state.layoutXY.setValue({
       // This is hacky, but we need to make sure that the value is never 0
       x: width || 0.001,

--- a/src/TabView.js
+++ b/src/TabView.js
@@ -2,7 +2,13 @@
 
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { Animated, View, StyleSheet, I18nManager, Platform } from 'react-native';
+import { 
+  Animated, 
+  View, 
+  StyleSheet, 
+  I18nManager, 
+  Platform 
+} from 'react-native';
 import TabBar from './TabBar';
 import PagerDefault from './PagerDefault';
 import { NavigationStatePropType } from './PropTypes';
@@ -84,9 +90,13 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
     });
     const position = Animated.add(
       Animated.multiply(
-        Animated.divide(Animated.add(panX, offsetX), layoutXY.x),
+        Animated.divide(
+          Animated.add(panX, offsetX),
+          layoutXY.x
+        ),
         -1),
-      I18nManager.isRTL && Platform.OS !== 'ios' ? navigationState.routes.length - 1 : 0
+      I18nManager.isRTL && Platform.OS !== 'ios' ?
+        navigationState.routes.length - 1 : 0
     );
 
     this.state = {
@@ -122,8 +132,10 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
     ) {
       return;
     }
-
-    this.state.offsetX.setValue((I18nManager.isRTL && Platform.OS !== 'ios'? this.props.navigationState.routes.length - 1 - this.props.navigationState.index : -this.props.navigationState.index) * width);
+    const { navigationState } = this.props;
+    this.state.offsetX.setValue((I18nManager.isRTL && Platform.OS !== 'ios' ?
+      navigationState.routes.length - 1 - navigationState.index
+      : -navigationState.index) * width);
     this.state.layoutXY.setValue({
       // This is hacky, but we need to make sure that the value is never 0
       x: width || 0.001,

--- a/src/TabView.js
+++ b/src/TabView.js
@@ -7,7 +7,7 @@ import {
   View, 
   StyleSheet, 
   I18nManager, 
-  Platform 
+  Platform, 
 } from 'react-native';
 import TabBar from './TabBar';
 import PagerDefault from './PagerDefault';
@@ -90,13 +90,9 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
     });
     const position = Animated.add(
       Animated.multiply(
-        Animated.divide(
-          Animated.add(panX, offsetX),
-          layoutXY.x
-        ),
-        -1),
-      I18nManager.isRTL && Platform.OS !== 'ios' ?
-        navigationState.routes.length - 1 : 0
+        Animated.divide(Animated.add(panX,offsetX),layoutXY.x),-1),
+        I18nManager.isRTL && Platform.OS !== 'ios' ?
+          navigationState.routes.length - 1 : 0
     );
 
     this.state = {

--- a/src/TabView.js
+++ b/src/TabView.js
@@ -94,8 +94,8 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
         -1
       ),
       I18nManager.isRTL && Platform.OS !== 'ios'
-      ? navigationState.routes.length - 1
-       : 0
+        ? navigationState.routes.length - 1
+        : 0
     );
 
     this.state = {

--- a/src/TabView.js
+++ b/src/TabView.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { 
+import {
   Animated,
   View,
   StyleSheet,
@@ -90,11 +90,11 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
     });
     const position = Animated.add(
       Animated.multiply(
-        Animated.divide(Animated.add(panX,offsetX),layoutXY.x),
-          -1
-        ),
-        I18nManager.isRTL && Platform.OS !== 'ios'
-        ? navigationState.routes.length - 1 : 0
+      Animated.divide(Animated.add(panX,offsetX), layoutXY.x),
+        -1
+      ),
+      I18nManager.isRTL && Platform.OS !== 'ios'
+      ? navigationState.routes.length - 1 : 0
     );
 
     this.state = {
@@ -131,8 +131,9 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
       return;
     }
     const { navigationState } = this.props;
-    this.state.offsetX.setValue((I18nManager.isRTL && Platform.OS !== 'ios'?
-      navigationState.routes.length - 1 - navigationState.index
+    this.state.offsetX.setValue(
+      (I18nManager.isRTL && Platform.OS !== 'ios'
+      ? navigationState.routes.length - 1 - navigationState.index
       : -navigationState.index) * width
     );
     this.state.layoutXY.setValue({

--- a/src/TabView.js
+++ b/src/TabView.js
@@ -3,11 +3,11 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { 
-  Animated, 
-  View, 
-  StyleSheet, 
-  I18nManager, 
-  Platform, 
+  Animated,
+  View,
+  StyleSheet,
+  I18nManager,
+  Platform,
 } from 'react-native';
 import TabBar from './TabBar';
 import PagerDefault from './PagerDefault';
@@ -90,8 +90,10 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
     });
     const position = Animated.add(
       Animated.multiply(
-        Animated.divide(Animated.add(panX,offsetX),layoutXY.x),-1),
-        I18nManager.isRTL && Platform.OS !== 'ios' 
+        Animated.divide(Animated.add(panX,offsetX),layoutXY.x),
+          -1
+        ),
+        I18nManager.isRTL && Platform.OS !== 'ios'
         ? navigationState.routes.length - 1 : 0
     );
 
@@ -129,7 +131,7 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
       return;
     }
     const { navigationState } = this.props;
-    this.state.offsetX.setValue((I18nManager.isRTL && Platform.OS !== 'ios' ?
+    this.state.offsetX.setValue((I18nManager.isRTL && Platform.OS !== 'ios'?
       navigationState.routes.length - 1 - navigationState.index
       : -navigationState.index) * width
     );


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

This pull requests adds support for RTL problems described in the following issue: #184

Animations, indicator and focus are off when in RTL. Notice the indicator doesn't change when moving between tabs and label focus is off as well.

The culprit for most issues seems to be in calculating the position in TabView.

### Test plan

- Test on RTL configured device (e.g. Arabic)
- Use Android's Developer Options -> Force RTL
- Add code in the app: I18nManager.forceRTL(true)