### PR TITLE
Update tabbar to be more performant if you are using ios and nativeDriver

### DIFF
--- a/src/PagerExperimental.js
+++ b/src/PagerExperimental.js
@@ -9,6 +9,7 @@ import type { PagerRendererProps } from './TypeDefinitions';
 type Props<T> = PagerRendererProps<T> & {
   swipeDistanceThreshold?: number,
   swipeVelocityThreshold?: number,
+  minXDelta?: number,
   GestureHandler: any,
 };
 

--- a/src/PagerExperimental.js
+++ b/src/PagerExperimental.js
@@ -9,7 +9,7 @@ import type { PagerRendererProps } from './TypeDefinitions';
 type Props<T> = PagerRendererProps<T> & {
   swipeDistanceThreshold?: number,
   swipeVelocityThreshold?: number,
-  minXDelta?: number,
+  minDeltaX?: number,
   GestureHandler: any,
 };
 
@@ -24,7 +24,7 @@ export default class PagerExperimental<T: *> extends React.Component<Props<T>> {
     ...PagerRendererPropType,
     swipeDistanceThreshold: PropTypes.number,
     swipeVelocityThreshold: PropTypes.number,
-    minXDelta: PropTypes.number,
+    minDeltaX: PropTypes.number,
     GestureHandler: PropTypes.object,
   };
 
@@ -151,7 +151,7 @@ export default class PagerExperimental<T: *> extends React.Component<Props<T>> {
       navigationState,
       swipeEnabled,
       children,
-      minXDelta = 10
+      minDeltaX = 10
     } = this.props;
     const { width } = layout;
     const { routes } = navigationState;
@@ -168,7 +168,7 @@ export default class PagerExperimental<T: *> extends React.Component<Props<T>> {
     return (
       <GestureHandler.PanGestureHandler
         enabled={layout.width !== 0 && swipeEnabled !== false}
-        minDeltaX={minXDelta}
+        minDeltaX={minDeltaX}
         onGestureEvent={Animated.event(
           [{ nativeEvent: { translationX: this.props.panX } }],
           { useNativeDriver: this.props.useNativeDriver }

--- a/src/PagerExperimental.js
+++ b/src/PagerExperimental.js
@@ -23,6 +23,7 @@ export default class PagerExperimental<T: *> extends React.Component<Props<T>> {
     ...PagerRendererPropType,
     swipeDistanceThreshold: PropTypes.number,
     swipeVelocityThreshold: PropTypes.number,
+    minXDelta: PropTypes.number,
     GestureHandler: PropTypes.object,
   };
 
@@ -149,6 +150,7 @@ export default class PagerExperimental<T: *> extends React.Component<Props<T>> {
       navigationState,
       swipeEnabled,
       children,
+      minXDelta = 10
     } = this.props;
     const { width } = layout;
     const { routes } = navigationState;
@@ -165,7 +167,7 @@ export default class PagerExperimental<T: *> extends React.Component<Props<T>> {
     return (
       <GestureHandler.PanGestureHandler
         enabled={layout.width !== 0 && swipeEnabled !== false}
-        minDeltaX={10}
+        minDeltaX={minXDelta}
         onGestureEvent={Animated.event(
           [{ nativeEvent: { translationX: this.props.panX } }],
           { useNativeDriver: this.props.useNativeDriver }

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -303,7 +303,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
             this.props,
             this._getScrollAmount(this.props, value)
           ),
-          animated: !this._isIntial, // Disable animation for the initial render
+          animated: useNativeDriver ? false : !this._isIntial, // Disable animation for the initial render
         });
 
       this._isIntial = false;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Currently am using the experimental pager and have found that the tabbar is lagging when scrollEnabled is set to true (ios only) when scrolling through tabs. To fix this i saw that we were setting animation on the scrollTo which was causing this issue. 

### Test plan

Create 4+ tabs which is 100% the screen width and have a long enough title so that the list of items will cause a scroll on the TabBar. Navigate to a new tab. View the lag between when the indicator is and what is present on the screen 
