### PR TITLE
README `renderScene` code example fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,13 +245,14 @@ All the scenes rendered with `SceneMap` are optimized using `React.PureComponent
 ```js
 renderScene = ({ route }) => {
   switch (route.key) {
-  case 'first':
-    return <FirstRoute />;
-  case 'second':
-    return <SecondRoute />;
-  default:
-    return null;
+    case 'first':
+      return <FirstRoute />;
+    case 'second':
+      return <SecondRoute />;
+    default:
+      return null;
   }
+}
 ```
 
 If you don't use `SceneMap`, you will need to take care of optimizing the individual scenes.


### PR DESCRIPTION
The code in the example missed close bracket.

### Motivation

Fixing typo.

### Test plan

Just check `API reference -> SceneMap` section.
