### PR TITLE
Feature Request: Indicator Style - Center 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # React Native Tab View
 
-[![Build Status][build-badge]][build]
-[![Version][version-badge]][package]
-[![MIT License][license-badge]][license]
+This is a React Navigation specific temporary fork of React Native Tab View.
+
+<hr />
 
 A cross-platform Tab View component for React Native.
 

--- a/example/src/NoAnimationExample.js
+++ b/example/src/NoAnimationExample.js
@@ -93,7 +93,7 @@ export default class TopBarIconExample extends React.Component<*, State> {
         return (
           <TouchableWithoutFeedback
             key={route.key}
-            onPress={() => props.jumpToIndex(index)}
+            onPress={() => props.jumpTo(route.key)}
           >
             <Animated.View style={styles.tab}>
               {this._renderIcon(props)({ route, index })}

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import {
   Animated,
+  NativeModules,
   StyleSheet,
   View,
   ScrollView,
@@ -43,6 +44,8 @@ type State = {|
   scrollAmount: Animated.Value,
   initialOffset: ?{| x: number, y: number |},
 |};
+
+const useNativeDriver = Boolean(NativeModules.NativeAnimatedModule);
 
 export default class TabBar<T: *> extends React.Component<Props<T>, State> {
   static propTypes = {
@@ -379,7 +382,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
                   },
                 },
               ],
-              { useNativeDriver: true, listener: this._handleScroll }
+              { useNativeDriver, listener: this._handleScroll }
             )}
             onScrollBeginDrag={this._handleBeginDrag}
             onScrollEndDrag={this._handleEndDrag}

--- a/src/TabViewPagerAndroid.web.js
+++ b/src/TabViewPagerAndroid.web.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Text } from 'react-native';
+
+export default class TabViewPagerAndroid<T: *> extends React.Component<
+  Props<T>
+> {
+  render() {
+    return (
+      <Text>The TabViewPagerAndroid is not supported on React Native Web</Text>
+    );
+  }
+}


### PR DESCRIPTION
I've searched through Stack Overflow, The official Discord Channel and other locations and found lots of developers struggling to center the indicator on the tab view. This problem arises when the width of the indicator does not take up the full length of the tab itself.

Example Picture: 
![image](https://user-images.githubusercontent.com/7469722/46250389-12dc2580-c408-11e8-8594-ff07d0b0a1f6.png)


Reference: https://github.com/react-navigation/react-navigation.github.io/pull/243

### Motivation

A solution that isn't responsive but brute force is setting the left value to a mathematical formula of halves but it's too complex for beginner users and isn't very responsive. This should ideally be solved using indicatorStyle: {center: true, and it's true by default to not break existing codebases}. Unfortunately, this is implemented using an absolute positioning so I couldn't easily change it and make my own fix pr.