### PR TITLE
Add scrollEnabledDivisor prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ renderTabBar={props =>
 - `indicatorStyle`: style object for the active indicator.
 - `labelStyle`: style object for the tab item label.
 - `style`: style object for the tab bar.
-
+- `scrollEnabledDivisor`: if scrollable tabs have been enabled set the divisor that calculates the width of the tab
+ 
 ### `<PagerPan />`
 
 Cross-platform pager based on the [`PanResponder`](https://facebook.github.io/react-native/docs/panresponder.html).

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -24,7 +24,7 @@ type IndicatorProps<T> = SceneRendererProps<T> & {
 };
 
 type Props<T> = SceneRendererProps<T> & {
-  scrollEnabledDivisor?:number,
+  scrollEnabledDivisor?: number,
   scrollEnabled?: boolean,
   bounces?: boolean,
   pressColor?: string,

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -24,6 +24,7 @@ type IndicatorProps<T> = SceneRendererProps<T> & {
 };
 
 type Props<T> = SceneRendererProps<T> & {
+  scrollEnabledDivisor?:number,
   scrollEnabled?: boolean,
   bounces?: boolean,
   pressColor?: string,
@@ -251,6 +252,9 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
     }
 
     if (props.scrollEnabled) {
+      if (props.scrollEnabledDivisor && props.scrollEnabledDivisor > 0) {
+        return layout.width / props.scrollEnabledDivisor;
+      }
       return (layout.width / 5) * 2;
     }
 


### PR DESCRIPTION
### Motivation
The current implementation when scrollEnabled is set to true creates a width of each tab to be 40% the width of the screen. Adding this additional prop `scrollEnabledDivisor` allows the user to define the divisor so that they can have more control over the width of each tab.