### PR TITLE
Update offsetX and panX after index change

### DIFF
--- a/src/PagerScroll.js
+++ b/src/PagerScroll.js
@@ -63,6 +63,10 @@ export default class PagerScroll<T: *> extends React.Component<
     } else if (
       prevProps.navigationState.index !== this.props.navigationState.index
     ) {
+      const { navigationState, layout, offsetX, panX } = this.props;
+
+      offsetX.setValue(-navigationState.index * layout.width);
+      panX.setValue(0);
       this._scrollTo(amount);
     }
   }


### PR DESCRIPTION
`handleScroll` sets `offsetX` and `panX` values accounting in the current (old) index. On the other hand, in `TabView#handleLayout`, offsetX gets recalculated using the newly set index.

This change makes sure that `offsetX` and `panX` values are updated properly after new index has been set, so `handleLayout` does not deal with stale values.

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Solves #625, not sure if other approaches may be better.

### Test plan

Follow reproduction steps from the linked issue. Make sure to have the `TabView` wrapped into `SafeAreaView`.
