### PR TITLE
better performance  (Delay rendering of non-focused tabs to next tick)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Container component responsible for rendering and managing tabs.
 - `renderTabBar`: callback which returns a custom React Element to use as the tab bar.
 - `renderPager`: callback which returns a custom React Element to handle swipe gesture and animation.
 - `canJumpToTab`: callback which returns a boolean indicating whether jumping to the tab is allowed.
+- `delayRenderOfNonFocusedTabs`: delay the rendering of non-focused tabs to the next tick, for better initial loading time.
 - `initialLayout`: object containing the initial `height` and `width`, can be passed to prevent the one frame delay in rendering.
 - `tabBarPosition`: position of the tab bar, `'top'` or `'bottom'`. Defaults to `'top'`.
 


### PR DESCRIPTION
### Motivation

Delay rendering of non focused tabs to the next tick, for better performance.
In order to keep it opt-in and fully backward compatible, I decided to add a new prop: `delayRenderOfNonFocusedTabs` to `TabView`.
If you set this prop to true, your current tab will be rendered, and only on the next tick the other tabs will be rendered.
edge case: If you turn this option on, and the render time of the current tab is long, and the user is expected to switch to other tab very quickly, then he will see a blank tab for a split second. that's why this option is currently opt-in.

### Results:
When clicking on a group called "blamos2", you can see how much time it takes to load the group items in a page with many tabs, before and after the change 

|Before|After|
|---|---|
| ![ezgif com-resize](https://user-images.githubusercontent.com/8758348/47602778-1c977f80-d9ec-11e8-9f0e-c1be2719d824.gif)|![ezgif com-resize 1](https://user-images.githubusercontent.com/8758348/47602775-16090800-d9ec-11e8-9fd1-00277a0243bc.gif)   |
