### PR TITLE
fix: PagerPan not trigger onIndexChange when disable animation

### DIFF
--- a/src/PagerPan.js
+++ b/src/PagerPan.js
@@ -190,10 +190,12 @@ export default class PagerPan<T: *> extends React.Component<Props<T>> {
 
   _transitionTo = (index: number, animated: boolean = true) => {
     const offset = -index * this.props.layout.width;
+    const route = this.props.navigationState.routes[index];
 
     if (this.props.animationEnabled === false || animated === false) {
       this.props.panX.setValue(0);
       this.props.offsetX.setValue(offset);
+      this.props.jumpTo(route.key);
       return;
     }
 
@@ -210,7 +212,6 @@ export default class PagerPan<T: *> extends React.Component<Props<T>> {
       }),
     ]).start(({ finished }) => {
       if (finished) {
-        const route = this.props.navigationState.routes[index];
         this.props.jumpTo(route.key);
         this.props.onAnimationEnd && this.props.onAnimationEnd();
         this._pendingIndex = null;


### PR DESCRIPTION

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

`PagerPan` doesn't trigger `props.onIndexChange` when `animationEnabled={false}`. without `Animated.parallel` and it's finished callback, `PagerPan` doesn't call `props.jumpTo` to make it all right.

### Test plan

Use `PagerPan` and set `animationEnabled={false}`, should trigger `props.onIndexChange` correctly.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
