### PR TITLE
 Let tab switch earlier

### DIFF
--- a/src/PagerAndroid.js
+++ b/src/PagerAndroid.js
@@ -77,6 +77,15 @@ export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
   };
 
   _handlePageScroll = (e: PageScrollEvent) => {
+	  
+	let nextIndex = this._currentIndex;
+
+    const nextRoute = this.props.navigationState.routes[nextIndex];
+
+    if (this.props.canJumpToTab({ route: nextRoute })) {
+      this.props.jumpTo(nextRoute.key);
+    }
+	
     this.props.offsetX.setValue(
       this._getPageIndex(e.nativeEvent.position) * this.props.layout.width * -1
     );
@@ -94,9 +103,7 @@ export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
 
     const nextRoute = this.props.navigationState.routes[nextIndex];
 
-    if (this.props.canJumpToTab({ route: nextRoute })) {
-      this.props.jumpTo(nextRoute.key);
-    } else {
+    if (!this.props.canJumpToTab({ route: nextRoute })) {
       this._setPage(this.props.navigationState.index);
       this._currentIndex = this.props.navigationState.index;
     }

--- a/src/PagerAndroid.js
+++ b/src/PagerAndroid.js
@@ -85,7 +85,6 @@ export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
     if (this.props.canJumpToTab({ route: nextRoute })) {
       this.props.jumpTo(nextRoute.key);
     }
-	
     this.props.offsetX.setValue(
       this._getPageIndex(e.nativeEvent.position) * this.props.layout.width * -1
     );

--- a/src/PagerAndroid.js
+++ b/src/PagerAndroid.js
@@ -77,7 +77,6 @@ export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
   };
 
   _handlePageScroll = (e: PageScrollEvent) => {
-	  
 	let nextIndex = this._currentIndex;
 
     const nextRoute = this.props.navigationState.routes[nextIndex];


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
I found that TAB switching didn't start until the animation of the page had stopped completely, which made it feel like TAB switching was slow. I wanted to start TAB switching when my hand left the screen and the page had moved to the next page.
