### PR TITLE
Remove unused code which causes a flow error

### DIFF
--- a/src/TabView.js
+++ b/src/TabView.js
@@ -116,13 +116,6 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
     return this.props.renderScene(props);
   };
 
-  _shouldRenderScene = (index: number) => {
-    return (
-      !this.state.delayRenderOfNonFocusedTabs ||
-      this.props.navigationState.index === index
-    );
-  };
-
   _handleLayout = (e: any) => {
     const { height, width } = e.nativeEvent.layout;
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
There was a flow error. This fixes it.
```
Error ---------------------------------------------------- ../../node_modules/react-native-tab-view/src/TabView.js:121:8
Property `delayRenderOfNonFocusedTabs` is missing in `State` [1].
   ../../node_modules/react-native-tab-view/src/TabView.js:121:8
   121|       !this.state.delayRenderOfNonFocusedTabs ||
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
References:
   ../../node_modules/react-native-tab-view/src/TabView.js:41:70
    41| export default class TabView<T: *> extends React.Component<Props<T>, State> {
                                                                             ^^^^^ [1]
```

cc @Niryo 

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Flow passes
