### PR TITLE
TabBar to accept hardcode width for custom icon

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -236,6 +236,10 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
     const { layout, navigationState, tabStyle } = props;
     const flattened = StyleSheet.flatten(tabStyle);
 
+    if(tabStyle.width) {
+      return tabStyle.width
+    }
+
     if (flattened) {
       switch (typeof flattened.width) {
         case 'number':


### PR DESCRIPTION
Allows you to hardcode a width for custom icon components which is useful when creating a Tab Bar in a style similar to Instagram's search screen.