### PR TITLE
Expose accessibility properties from 'PagerAndroid'

### DIFF
--- a/src/PagerAndroid.js
+++ b/src/PagerAndroid.js
@@ -16,6 +16,8 @@ type PageScrollState = 'dragging' | 'settling' | 'idle';
 
 type Props<T> = PagerRendererProps<T> & {
   keyboardDismissMode: 'none' | 'on-drag',
+  accessible?: boolean,
+  importantForAccessibility?: 'auto' | 'yes' | 'no' | 'no-hide-descendants',
 };
 
 export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
@@ -24,6 +26,8 @@ export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
   static defaultProps = {
     canJumpToTab: () => true,
     keyboardDismissMode: 'on-drag',
+    accessible: true,
+    importantForAccessibility: 'auto',
   };
 
   constructor(props: Props<T>) {
@@ -120,7 +124,13 @@ export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
   };
 
   render() {
-    const { navigationState, swipeEnabled, keyboardDismissMode } = this.props;
+    const {
+      navigationState,
+      swipeEnabled,
+      keyboardDismissMode,
+      accessible,
+      importantForAccessibility,
+    } = this.props;
     const children = I18nManager.isRTL
       ? React.Children.toArray(this.props.children).reverse()
       : React.Children.toArray(this.props.children);
@@ -155,6 +165,8 @@ export default class PagerAndroid<T: *> extends React.Component<Props<T>> {
         onPageSelected={this._handlePageSelected}
         style={styles.container}
         ref={el => (this._viewPager = el)}
+        accessible={accessible}
+        importantForAccessibility={importantForAccessibility}
       >
         {content}
       </ViewPagerAndroid>

--- a/src/TypeDefinitions.js
+++ b/src/TypeDefinitions.js
@@ -57,4 +57,6 @@ export type PagerExtraProps = {
   keyboardDismissMode?: 'none' | 'on-drag',
   swipeDistanceThreshold?: number,
   swipeVelocityThreshold?: number,
+  accessible?: boolean,
+  importantForAccessibility?: 'auto' | 'yes' | 'no' | 'no-hide-descendants',
 };


### PR DESCRIPTION
Exposing basic accessibility properties 'accessible' and 'importantFor
Accessibility' from 'PagerAndroid'. This allow the 'ViewPagerAndroid'
to capture the focus or not, can be used to solve issue of Pager
capturing the focus from beneath(not active).

See #645.

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
