### PR TITLE
panX and offsetX need to be set together

### DIFF
--- a/src/TabView.js
+++ b/src/TabView.js
@@ -126,6 +126,7 @@ export default class TabView<T: *> extends React.Component<Props<T>, State> {
       return;
     }
 
+    this.state.panX.setValue(0);
     this.state.offsetX.setValue(-this.props.navigationState.index * width);
     this.state.layoutXY.setValue({
       // This is hacky, but we need to make sure that the value is never 0


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

The indicator is rendered in the wrong position when the height of the tab view changes.  To fix the calculation, the panX value needs to be set whenever setting the offsetX value.

### Test plan

1. Using `createMaterialTopTabNavigator`, create a navigator with a `tabBarComponent` that changes height when switching tabs.  See example below that has a banner on two tabs but not the last tab.
2. Swipe to tab with different height.
3. Swipe back to previous tab.

Expected Results: indicator is rendered under the active tab.
Actual Results: indicator is rendered under non-active tab.

<img width="280" alt="screen shot 2019-01-15 at 2 56 25 pm" src="https://user-images.githubusercontent.com/997786/51215484-e9bba400-18d5-11e9-9de9-5e9890cfcc2a.png">
<img width="281" alt="screen shot 2019-01-15 at 2 56 09 pm" src="https://user-images.githubusercontent.com/997786/51215485-e9bba400-18d5-11e9-999a-4e13dc11a821.png">
<img width="283" alt="screen shot 2019-01-15 at 2 59 44 pm" src="https://user-images.githubusercontent.com/997786/51215625-62bafb80-18d6-11e9-9078-d9f9f1aa96ac.png">
