### PR TITLE
Adding accessibility role and state

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -481,6 +481,8 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
                     isFocused ? ['button', 'selected'] : 'button'
                   }
                   accessibilityComponentType="button"
+                  accessibilityRole="button"
+                  accessibilityStates={isFocused ? ['selected'] : []}
                   pressColor={this.props.pressColor}
                   pressOpacity={this.props.pressOpacity}
                   delayPressIn={0}


### PR DESCRIPTION
### Motivation

Utilizing the new accessibility properties provided in react-native 0.57.0. It did not seem to work using the currently deprecated properties on my test devices.

### Test plan

Steps to test:
1. Enable VoiceOver (iOS) or TalkBack (Android)
2. Select a tab
3. It should read something like `Selected. TabName. Tab. x of y. Button`. Previously, it would read `TabName. Tab. x of y.`

It seems like there was an effort to manually assign the role of `Tab` through the `accessibilityLabel` prop. However, that is not in the list of available accessibility roles. Personally, I think it's helpful to have both `Tab` and `Button` announced, but I can remove/change it as needed.