### PR TITLE
Fix RTL tabview indicator position

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -360,7 +360,10 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
 
     // Prepend '-1', so there are always at least 2 items in inputRange
     const inputRange = [-1, ...routes.map((x, i) => i)];
-    const translateX = Animated.multiply(this.state.scrollAmount, -1);
+    const translateX = Animated.multiply(
+      this.state.scrollAmount,
+      I18nManager.isRTL ? 1 : -1
+    );
 
     return (
       <Animated.View style={[styles.tabBar, this.props.style]}>


### PR DESCRIPTION
This small change fixes indicator position for rtl layout with scroll-enabled on tabbar
indicator is not correctly aligned with the tab:
issue:
![ios-old](https://user-images.githubusercontent.com/9105978/52176735-78c62880-27bf-11e9-939a-24643dff7108.png)
fix:
![ios-correct](https://user-images.githubusercontent.com/9105978/52176739-811e6380-27bf-11e9-9831-3d6d276efe87.png)

code fixes the issue for ios, but for android i'm still having issues, maybe someone can help.

