### PR TITLE
feat: Adding props to override minHeight

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,10 @@ Boolean indicating whether the tab bar bounces when scrolling.
 
 Style to apply to the individual tabs in the tab bar.
 
+##### `tabBarItemStyle`
+
+ Complementary Style to apply to the individual tabs in the tab bar. (for example : overriding default minHeight, padding ...)
+ 
 ##### `indicatorStyle`
 
 Style to apply to the active indicator.

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -46,6 +46,7 @@ export type Props<T> = {|
   onTabPress?: (scene: Scene<T>) => mixed,
   onTabLongPress?: (scene: Scene<T>) => mixed,
   tabStyle?: ViewStyleProp,
+  tabBarItemStyle?: ViewStyleProp,
   indicatorStyle?: ViewStyleProp,
   labelStyle?: TextStyleProp,
   style?: ViewStyleProp,
@@ -255,6 +256,7 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
       onTabPress,
       onTabLongPress,
       tabStyle,
+      tabBarItemStyle,
       labelStyle,
       indicatorStyle,
       style,
@@ -345,6 +347,7 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
                 onLongPress={() => onTabLongPress && onTabLongPress({ route })}
                 labelStyle={labelStyle}
                 style={tabStyle}
+                tabBarItemStyle={tabBarItemStyle}
               />
             ))}
           </Animated.ScrollView>

--- a/src/TabBarItem.js
+++ b/src/TabBarItem.js
@@ -38,6 +38,7 @@ type Props<T> = {|
   onLongPress: () => mixed,
   tabWidth: number,
   labelStyle?: TextStyleProp,
+  tabBarItemStyle: ViewStyleProp,
   style: ViewStyleProp,
 |};
 
@@ -61,6 +62,7 @@ export default function TabBarItem<T: Route>({
   pressColor,
   pressOpacity,
   labelStyle,
+  tabBarItemStyle,
   style,
   tabWidth,
   onPress,
@@ -201,7 +203,10 @@ export default function TabBarItem<T: Route>({
       onLongPress={onLongPress}
       style={tabContainerStyle}
     >
-      <View pointerEvents="none" style={[styles.item, itemStyle]}>
+      <View
+        pointerEvents="none"
+        style={[styles.item, itemStyle, tabBarItemStyle]}
+      >
         {icon}
         {label}
         {badge != null ? <View style={styles.badge}>{badge}</View> : null}


### PR DESCRIPTION
 Due to some needs on a project I needed to be able to customize the minHeight of the tabBar but for now it was sealed so I decided to add tabBarItemStyle prop in order to be able to customize the item

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
The TabBar minHeight was not customizable and added always a 10 padding. It seems not possible to resolve this problem with a different approach as there is no style customization option for this element. 

### Test plan
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
on ScrollableTabBarExample.js on line 48 add the following
```js
tabBarItemStyle={{ minHeight: 0, padding: 0 }}
````
![image-1](https://user-images.githubusercontent.com/3941062/53296482-ddccd700-37dd-11e9-8f3b-71d87f922473.png)


