### PR TITLE
Add activeTabStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,10 @@ Boolean indicating whether the tab bar bounces when scrolling.
 
 Style to apply to the individual tab items in the tab bar.
 
+##### `activeTabContainerStyle`
+
+Style to apply to the active tab container item in the tab bar.
+
 ##### `indicatorStyle`
 
 Style to apply to the active indicator.

--- a/README.md
+++ b/README.md
@@ -414,9 +414,9 @@ Boolean indicating whether the tab bar bounces when scrolling.
 
 Style to apply to the individual tab items in the tab bar.
 
-##### `activeTabContainerStyle`
+##### `activeTabStyle`
 
-Style to apply to the active tab container item in the tab bar.
+Style to apply to the active individual tab item in the tab bar.
 
 ##### `indicatorStyle`
 

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -46,6 +46,7 @@ export type Props<T> = {|
   onTabPress?: (scene: Scene<T>) => mixed,
   onTabLongPress?: (scene: Scene<T>) => mixed,
   tabStyle?: ViewStyleProp,
+  activeTabContainerStyle?: ViewStyleProp,
   indicatorStyle?: ViewStyleProp,
   labelStyle?: TextStyleProp,
   contentContainerStyle?: ViewStyleProp,
@@ -266,6 +267,7 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
       onTabPress,
       onTabLongPress,
       tabStyle,
+      activeTabContainerStyle,
       labelStyle,
       indicatorStyle,
       contentContainerStyle,
@@ -357,6 +359,7 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
                 }}
                 onLongPress={() => onTabLongPress && onTabLongPress({ route })}
                 labelStyle={labelStyle}
+                activeTabContainerStyle={activeTabContainerStyle}
                 style={tabStyle}
               />
             ))}

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -46,7 +46,7 @@ export type Props<T> = {|
   onTabPress?: (scene: Scene<T>) => mixed,
   onTabLongPress?: (scene: Scene<T>) => mixed,
   tabStyle?: ViewStyleProp,
-  activeTabContainerStyle?: ViewStyleProp,
+  activeTabStyle?: ViewStyleProp,
   indicatorStyle?: ViewStyleProp,
   labelStyle?: TextStyleProp,
   contentContainerStyle?: ViewStyleProp,
@@ -267,7 +267,7 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
       onTabPress,
       onTabLongPress,
       tabStyle,
-      activeTabContainerStyle,
+      activeTabStyle,
       labelStyle,
       indicatorStyle,
       contentContainerStyle,
@@ -359,7 +359,7 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
                 }}
                 onLongPress={() => onTabLongPress && onTabLongPress({ route })}
                 labelStyle={labelStyle}
-                activeTabContainerStyle={activeTabContainerStyle}
+                activeTabStyle={activeTabStyle}
                 style={tabStyle}
               />
             ))}

--- a/src/TabBarItem.js
+++ b/src/TabBarItem.js
@@ -38,6 +38,7 @@ type Props<T> = {|
   onLongPress: () => mixed,
   tabWidth: number,
   labelStyle?: TextStyleProp,
+  activeTabContainerStyle?: ViewStyleProp,
   style: ViewStyleProp,
 |};
 
@@ -61,6 +62,7 @@ export default function TabBarItem<T: Route>({
   pressColor,
   pressOpacity,
   labelStyle,
+  activeTabContainerStyle = {},
   style,
   tabWidth,
   onPress,
@@ -164,13 +166,13 @@ export default function TabBarItem<T: Route>({
     (tabStyle && typeof tabStyle.width !== 'undefined') ||
     scrollEnabled === true;
 
-  const tabContainerStyle = {};
+  let tabContainerStyle = isFocused ? activeTabContainerStyle : {};
   const itemStyle = isWidthSet ? { width: tabWidth } : null;
 
   if (tabStyle && typeof tabStyle.flex === 'number') {
-    tabContainerStyle.flex = tabStyle.flex;
+    tabContainerStyle = StyleSheet.flatten([{flex: tabStyle.flex}, tabContainerStyle]);
   } else if (!isWidthSet) {
-    tabContainerStyle.flex = 1;
+    tabContainerStyle = StyleSheet.flatten([{flex: 1}, tabContainerStyle]);
   }
 
   const scene = { route };

--- a/src/TabBarItem.js
+++ b/src/TabBarItem.js
@@ -38,7 +38,7 @@ type Props<T> = {|
   onLongPress: () => mixed,
   tabWidth: number,
   labelStyle?: TextStyleProp,
-  activeTabContainerStyle?: ViewStyleProp,
+  activeTabStyle?: ViewStyleProp,
   style: ViewStyleProp,
 |};
 
@@ -62,7 +62,7 @@ export default function TabBarItem<T: Route>({
   pressColor,
   pressOpacity,
   labelStyle,
-  activeTabContainerStyle = {},
+  activeTabStyle = {},
   style,
   tabWidth,
   onPress,
@@ -166,13 +166,15 @@ export default function TabBarItem<T: Route>({
     (tabStyle && typeof tabStyle.width !== 'undefined') ||
     scrollEnabled === true;
 
-  let tabContainerStyle = isFocused ? activeTabContainerStyle : {};
+  const tabContainerStyle = {};
   const itemStyle = isWidthSet ? { width: tabWidth } : null;
 
+  const isActiveStyle = isFocused && activeTabStyle != null;
+
   if (tabStyle && typeof tabStyle.flex === 'number') {
-    tabContainerStyle = StyleSheet.flatten([{flex: tabStyle.flex}, tabContainerStyle]);
+    tabContainerStyle.flex = isActiveStyle ? activeTabStyle.flex : tabStyle.flex;
   } else if (!isWidthSet) {
-    tabContainerStyle = StyleSheet.flatten([{flex: 1}, tabContainerStyle]);
+    tabContainerStyle.flex = 1;
   }
 
   const scene = { route };
@@ -203,7 +205,7 @@ export default function TabBarItem<T: Route>({
       onLongPress={onLongPress}
       style={tabContainerStyle}
     >
-      <View pointerEvents="none" style={[styles.item, itemStyle, tabStyle]}>
+      <View pointerEvents="none" style={[styles.item, itemStyle, isActiveStyle ? activeTabStyle : tabStyle]}>
         {icon}
         {label}
         {badge != null ? <View style={styles.badge}>{badge}</View> : null}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

There's no proper way to change the container style of a focused item.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
1. Add `activeTabStyle` with a distinguish style to `TabBar`
2. Select a tab
