### PR TITLE
Control removing clipped subviews via prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ By default, this renders `null`.
 
 ##### `removeClippedSubviews`
 
-Removes not visible subviews to improve memory usage. Defaults to `false`.
+Boolean indicating whether to remove invisible views (such as unfocused screens) from the native view hierarchy to improve memory usage. Defaults to `false`.
 
 **Note**: Don't enable this on iOS where this is buggy and views don't re-appear.
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,15 @@ This view is usually only shown for a split second. Keep it lightweight.
 
 By default, this renders `null`.
 
+
+##### `removeClippedSubviews`
+
+*Note*: Don't enable this on iOS where this is buggy and views don't re-appear.
+
+Removes not visible subviews to improve memory usage.
+
+`false` by default.
+
 ##### `keyboardDismissMode`
 
 String indicating whether the keyboard gets dismissed in response to a drag gesture. Possible values are:

--- a/README.md
+++ b/README.md
@@ -252,11 +252,9 @@ By default, this renders `null`.
 
 ##### `removeClippedSubviews`
 
-*Note*: Don't enable this on iOS where this is buggy and views don't re-appear.
+Removes not visible subviews to improve memory usage. Defaults to `false`.
 
-Removes not visible subviews to improve memory usage.
-
-`false` by default.
+**Note**: Don't enable this on iOS where this is buggy and views don't re-appear.
 
 ##### `keyboardDismissMode`
 

--- a/src/Pager.js
+++ b/src/Pager.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import * as React from 'react';
-import { StyleSheet, Platform, Keyboard } from 'react-native';
+import { StyleSheet, Keyboard } from 'react-native';
 import { PanGestureHandler, State } from 'react-native-gesture-handler';
 import Animated, { Easing } from 'react-native-reanimated';
 
@@ -72,6 +72,9 @@ type Props<T: Route> = {|
   onIndexChange: (index: number) => mixed,
   navigationState: NavigationState<T>,
   layout: Layout,
+  // Clip unfocused views to improve memory usage
+  // Don't enable this on iOS where this is buggy and views don't re-appear
+  removeClippedSubviews?: boolean,
   children: (props: {|
     // Animated value which represents the state of current index
     // It can include fractional digits as it represents the intermediate value
@@ -444,7 +447,13 @@ export default class Pager<T: Route> extends React.Component<Props<T>> {
   ]);
 
   render() {
-    const { layout, navigationState, swipeEnabled, children } = this.props;
+    const {
+      layout,
+      navigationState,
+      swipeEnabled,
+      children,
+      removeClippedSubviews,
+    } = this.props;
 
     // Make sure that the translation doesn't exceed the bounds to prevent overscrolling
     const translateX = min(
@@ -479,11 +488,7 @@ export default class Pager<T: Route> extends React.Component<Props<T>> {
           failOffsetY={[-SWIPE_DISTANCE_MINIMUM, SWIPE_DISTANCE_MINIMUM]}
         >
           <Animated.View
-            removeClippedSubviews={
-              // Clip unfocused views to improve meory usage
-              // Don't enable this on iOS where this is buggy and views don't re-appear
-              Platform.OS !== 'ios'
-            }
+            removeClippedSubviews={removeClippedSubviews}
             style={[
               styles.container,
               layout.width

--- a/src/TabView.js
+++ b/src/TabView.js
@@ -32,6 +32,7 @@ type Props<T: Route> = {|
   tabBarPosition: 'top' | 'bottom',
   initialLayout?: { width?: number, height?: number },
   lazy: boolean,
+  removeClippedSubviews?: boolean,
   sceneContainerStyle?: ViewStyleProp,
   style?: ViewStyleProp,
 |};
@@ -51,6 +52,7 @@ export default class TabView<T: Route> extends React.Component<
     keyboardDismissMode: 'on-drag',
     swipeEnabled: true,
     lazy: false,
+    removeClippedSubviews: false,
   };
 
   state = {
@@ -87,6 +89,7 @@ export default class TabView<T: Route> extends React.Component<
       onSwipeEnd,
       navigationState,
       lazy,
+      removeClippedSubviews,
       keyboardDismissMode,
       swipeEnabled,
       swipeDistanceThreshold,
@@ -112,6 +115,7 @@ export default class TabView<T: Route> extends React.Component<
           onSwipeStart={onSwipeStart}
           onSwipeEnd={onSwipeEnd}
           onIndexChange={this._jumpToIndex}
+          removeClippedSubviews={removeClippedSubviews}
         >
           {({ position, render, addListener, removeListener, jumpTo }) => {
             // All of the props here must not change between re-renders


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

In one of my projects, setting `removeClippedSubviews` to true on Android caused some performance issue.
This PR gives control of this behavior to lib consumer.

### Test plan

Green CI
