### PR TITLE
fix: change index when we know the next index

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -19,6 +19,7 @@ import TabBarIconExample from './TabBarIconExample';
 import CustomIndicatorExample from './CustomIndicatorExample';
 import CustomTabBarExample from './CustomTabBarExample';
 import CoverflowExample from './CoverflowExample';
+import FastIndexChange from './FastIndexChange';
 
 YellowBox.ignoreWarnings(['bind():']);
 
@@ -30,6 +31,7 @@ const EXAMPLE_COMPONENTS = [
   CustomIndicatorExample,
   CustomTabBarExample,
   CoverflowExample,
+  FastIndexChange,
 ];
 
 type State = {

--- a/example/src/FastIndexChange.js
+++ b/example/src/FastIndexChange.js
@@ -1,0 +1,73 @@
+/* @flow */
+
+import * as React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { TabView, TabBar, type NavigationState } from 'react-native-tab-view';
+
+const FirstRoute = ({ active }) => (
+  <View style={[styles.scene, { backgroundColor: active ? 'pink' : '#fff' }]} />
+);
+
+const SecondRoute = ({ active }) => (
+  <View style={[styles.scene, { backgroundColor: active ? 'pink' : '#fff' }]} />
+);
+
+const ThirdScene = ({ active }) => (
+  <View style={[styles.scene, { backgroundColor: active ? 'pink' : '#fff' }]} />
+);
+
+type State = NavigationState<{
+  key: string,
+  title: string,
+}>;
+
+export default class FastIndexChangeExample extends React.Component<*, State> {
+  static title = 'Fast index change';
+  static backgroundColor = '#2196f3';
+  static tintColor = '#fff';
+  static appbarElevation = 0;
+  static statusBarStyle = 'light-content';
+
+  state = {
+    index: 0,
+    routes: [
+      { key: 'first', title: 'First' },
+      { key: 'second', title: 'Second' },
+      { key: 'third', title: 'Third' },
+    ],
+  };
+
+  _renderScene = ({ route }) => {
+    if (route.key === 'first') {
+      return <FirstRoute active={this.state.index === 0} />;
+    }
+    if (route.key === 'second') {
+      return <SecondRoute active={this.state.index === 1} />;
+    }
+    if (route.key === 'third') {
+      return <ThirdScene active={this.state.index === 2} />;
+    }
+  };
+
+  _handleIndexChange = index => this.setState({ index });
+
+  _renderTabBar = props => <TabBar {...props} scrollEnabled />;
+
+  render() {
+    return (
+      <TabView
+        style={this.props.style}
+        navigationState={this.state}
+        renderScene={this._renderScene}
+        renderTabBar={this._renderTabBar}
+        onIndexChange={this._handleIndexChange}
+      />
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  scene: {
+    flex: 1,
+  },
+});

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -6409,7 +6409,7 @@ react-native-gesture-handler@~1.0.14:
     invariant "^2.2.2"
     prop-types "^15.5.10"
 
-react-native-maps@expo/react-native-maps#v0.22.1-exp.0:
+"react-native-maps@github:expo/react-native-maps#v0.22.1-exp.0":
   version "0.22.1"
   resolved "https://codeload.github.com/expo/react-native-maps/tar.gz/e6f98ff7272e5d0a7fe974a41f28593af2d77bb2"
 

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -6409,7 +6409,7 @@ react-native-gesture-handler@~1.0.14:
     invariant "^2.2.2"
     prop-types "^15.5.10"
 
-"react-native-maps@github:expo/react-native-maps#v0.22.1-exp.0":
+react-native-maps@expo/react-native-maps#v0.22.1-exp.0:
   version "0.22.1"
   resolved "https://codeload.github.com/expo/react-native-maps/tar.gz/e6f98ff7272e5d0a7fe974a41f28593af2d77bb2"
 

--- a/src/Pager.js
+++ b/src/Pager.js
@@ -284,6 +284,11 @@ export default class Pager<T: Route> extends React.Component<Props<T>> {
         set(state.finished, FALSE),
         set(this._index, index),
         startClock(this._clock),
+        call([this._index], ([value]) => {
+          // set current index so componentDidUpdate not trigger new onIndexChange causing double swipe
+          this._currentIndexValue = value;
+          this.props.onIndexChange(value);
+        }),
       ]),
       cond(
         this._isSwipeGesture,
@@ -307,9 +312,6 @@ export default class Pager<T: Route> extends React.Component<Props<T>> {
         // When the animation finishes, stop the clock
         stopClock(this._clock),
         call([this._index], ([value]) => {
-          // If the index changed, and previous animation has finished, update state
-          this.props.onIndexChange(value);
-
           // Without this check, the pager can go to an infinite update <-> animate loop for sync updates
           if (value !== this.props.navigationState.index) {
             this._pendingIndexValue = value;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Regarding this issue https://github.com/react-native-community/react-native-tab-view/issues/716

### Test plan

Added a new example FastIndexChange. The screen is active if it's pink, before this change it took around 1s before the new screen got pink. Now it's instant.
