### PR TITLE
Support horizontal bounces for PagerScoll to make it looks like iOS component

### DIFF
--- a/example/src/TopBarIconExample.js
+++ b/example/src/TopBarIconExample.js
@@ -69,6 +69,7 @@ export default class TopBarIconExample extends React.Component<*, State> {
         renderScene={this._renderScene}
         renderTabBar={this._renderTabBar}
         onIndexChange={this._handleIndexChange}
+        bouncesEnabled // only iOS
       />
     );
   }

--- a/example/src/TopBarIconExample.js
+++ b/example/src/TopBarIconExample.js
@@ -69,7 +69,7 @@ export default class TopBarIconExample extends React.Component<*, State> {
         renderScene={this._renderScene}
         renderTabBar={this._renderTabBar}
         onIndexChange={this._handleIndexChange}
-        bouncesEnabled // only iOS
+        bounces // only iOS
       />
     );
   }

--- a/example/src/TopBarTextExample.js
+++ b/example/src/TopBarTextExample.js
@@ -73,7 +73,7 @@ export default class TopBarTextExample extends React.Component<*, State> {
         renderTabBar={this._renderTabBar}
         onIndexChange={this._handleIndexChange}
         initialLayout={initialLayout}
-        bouncesEnabled // only iOS
+        bounces // only iOS
       />
     );
   }

--- a/example/src/TopBarTextExample.js
+++ b/example/src/TopBarTextExample.js
@@ -73,6 +73,7 @@ export default class TopBarTextExample extends React.Component<*, State> {
         renderTabBar={this._renderTabBar}
         onIndexChange={this._handleIndexChange}
         initialLayout={initialLayout}
+        bouncesEnabled // only iOS
       />
     );
   }

--- a/src/PagerScroll.js
+++ b/src/PagerScroll.js
@@ -140,7 +140,7 @@ export default class PagerScroll<T: *> extends React.Component<
       navigationState,
       onSwipeStart,
       onSwipeEnd,
-      bouncesEnabled,
+      bounces,
     } = this.props;
 
     return (
@@ -153,8 +153,8 @@ export default class PagerScroll<T: *> extends React.Component<
         overScrollMode="never"
         scrollEnabled={this.props.swipeEnabled}
         automaticallyAdjustContentInsets={false}
-        bounces={bouncesEnabled || false} // default false
-        alwaysBounceHorizontal={bouncesEnabled || false} // default false
+        bounces={bounces || false} // default false
+        alwaysBounceHorizontal={bounces || false} // default false
         scrollsToTop={false}
         showsHorizontalScrollIndicator={false}
         scrollEventThrottle={1}

--- a/src/PagerScroll.js
+++ b/src/PagerScroll.js
@@ -152,8 +152,8 @@ export default class PagerScroll<T: *> extends React.Component<
         overScrollMode="never"
         scrollEnabled={this.props.swipeEnabled}
         automaticallyAdjustContentInsets={false}
-        bounces={false}
-        alwaysBounceHorizontal={false}
+        bounces
+        alwaysBounceHorizontal
         scrollsToTop={false}
         showsHorizontalScrollIndicator={false}
         scrollEventThrottle={1}

--- a/src/PagerScroll.js
+++ b/src/PagerScroll.js
@@ -32,6 +32,7 @@ export default class PagerScroll<T: *> extends React.Component<
 
   static defaultProps = {
     canJumpToTab: () => true,
+    bounces: false,
   };
 
   constructor(props: Props<T>) {
@@ -153,8 +154,8 @@ export default class PagerScroll<T: *> extends React.Component<
         overScrollMode="never"
         scrollEnabled={this.props.swipeEnabled}
         automaticallyAdjustContentInsets={false}
-        bounces={bounces || false} // default false
-        alwaysBounceHorizontal={bounces || false} // default false
+        bounces={bounces}
+        alwaysBounceHorizontal={bounces}
         scrollsToTop={false}
         showsHorizontalScrollIndicator={false}
         scrollEventThrottle={1}

--- a/src/PagerScroll.js
+++ b/src/PagerScroll.js
@@ -140,6 +140,7 @@ export default class PagerScroll<T: *> extends React.Component<
       navigationState,
       onSwipeStart,
       onSwipeEnd,
+      bouncesEnabled,
     } = this.props;
 
     return (
@@ -152,8 +153,8 @@ export default class PagerScroll<T: *> extends React.Component<
         overScrollMode="never"
         scrollEnabled={this.props.swipeEnabled}
         automaticallyAdjustContentInsets={false}
-        bounces
-        alwaysBounceHorizontal
+        bounces={bouncesEnabled || false} // default false
+        alwaysBounceHorizontal={bouncesEnabled || false} // default false
         scrollsToTop={false}
         showsHorizontalScrollIndicator={false}
         scrollEventThrottle={1}

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -40,6 +40,7 @@ export const PagerRendererPropType = {
   jumpTo: PropTypes.func.isRequired,
   animationEnabled: PropTypes.bool,
   swipeEnabled: PropTypes.bool,
+  bounces: PropTypes.bool.isRequired,
   useNativeDriver: PropTypes.bool,
   onSwipeStart: PropTypes.func,
   onSwipeEnd: PropTypes.func,

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -213,8 +213,8 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
     const translateX = Animated.multiply(
       Animated.multiply(
         position.interpolate({
-          inputRange: [0, navigationState.routes.length - 1],
-          outputRange: [0, navigationState.routes.length - 1],
+          inputRange: [-1, navigationState.routes.length],
+          outputRange: [-1, navigationState.routes.length],
           extrapolate: 'clamp',
         }),
         width

--- a/src/TypeDefinitions.js
+++ b/src/TypeDefinitions.js
@@ -46,6 +46,7 @@ export type PagerRendererProps<T> = PagerCommonProps<T> & {
 export type PagerCommonProps<T> = {
   animationEnabled?: boolean,
   swipeEnabled?: boolean,
+  bouncesEnabled?: boolean,
   onSwipeStart?: () => mixed,
   onSwipeEnd?: () => mixed,
   onAnimationEnd?: () => mixed,

--- a/src/TypeDefinitions.js
+++ b/src/TypeDefinitions.js
@@ -46,7 +46,7 @@ export type PagerRendererProps<T> = PagerCommonProps<T> & {
 export type PagerCommonProps<T> = {
   animationEnabled?: boolean,
   swipeEnabled?: boolean,
-  bouncesEnabled?: boolean,
+  bounces?: boolean,
   onSwipeStart?: () => mixed,
   onSwipeEnd?: () => mixed,
   onAnimationEnd?: () => mixed,


### PR DESCRIPTION
### Motivation

Currently the Pager bounce is disabled and it looks like an Android Pager not iOS scrollview.
Support horizontal bounces for `PagerScoll` to make it looks like an iOS component.

`bouncesEnabled` props is default `false` to avoid affecting existing users.

This PR is for v1.0 because most developers are still using this version.
I will create another PR for v2.0 as soon as possible.

![ezgif com-video-to-gif (10)](https://user-images.githubusercontent.com/1034290/54703990-d696b000-4b74-11e9-8017-7bf8d8c797c0.gif)

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
