### PR TITLE
RTL support in scrollEnabled Tabbar [Android]

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -191,10 +191,7 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
 
       this._scrollView &&
         this._scrollView.scrollTo({
-          x: this._normalizeScrollValue(
-            this.props,
-            this._getScrollAmount(this.props, value)
-          ),
+          x: this._getScrollAmount(this.props, value),
           animated: false,
         });
     }

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -67,8 +67,8 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
       typeof route.accessibilityLabel === 'string'
         ? route.accessibilityLabel
         : typeof route.title === 'string'
-          ? route.title
-          : undefined,
+        ? route.title
+        : undefined,
     getTestID: ({ route }: Scene<T>) => route.testID,
     renderIndicator: (props: IndicatorProps<T>) => (
       <TabBarIndicator {...props} />

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -173,7 +173,7 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
     const maxDistance = tabBarWidth - layout.width;
     let result = Math.max(Math.min(value, maxDistance), 0);
 
-    return I18nManager.isRTL ? maxDistance - result : result;
+    return I18nManager.isRTL ? layout.width - result : result;
   };
 
   _getScrollAmount = (props, i) => {

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import * as React from 'react';
-import { StyleSheet, View, ScrollView } from 'react-native';
+import { StyleSheet, View, ScrollView, I18nManager } from 'react-native';
 import Animated from 'react-native-reanimated';
 import TabBarItem from './TabBarItem';
 import TabBarIndicator, {
@@ -67,8 +67,8 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
       typeof route.accessibilityLabel === 'string'
         ? route.accessibilityLabel
         : typeof route.title === 'string'
-        ? route.title
-        : undefined,
+          ? route.title
+          : undefined,
     getTestID: ({ route }: Scene<T>) => route.testID,
     renderIndicator: (props: IndicatorProps<T>) => (
       <TabBarIndicator {...props} />
@@ -171,8 +171,9 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
       layout.width
     );
     const maxDistance = tabBarWidth - layout.width;
+    let result = Math.max(Math.min(value, maxDistance), 0);
 
-    return Math.max(Math.min(value, maxDistance), 0);
+    return I18nManager.isRTL ? maxDistance - result : result;
   };
 
   _getScrollAmount = (props, i) => {
@@ -292,6 +293,7 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
             layout,
             navigationState,
             jumpTo,
+            scrollEnabled,
             addListener,
             removeListener,
             width: tabWidth,

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -1,7 +1,13 @@
 /* @flow */
 
 import * as React from 'react';
-import { StyleSheet, View, ScrollView, I18nManager } from 'react-native';
+import {
+  StyleSheet,
+  View,
+  ScrollView,
+  I18nManager,
+  Platform,
+} from 'react-native';
 import Animated from 'react-native-reanimated';
 import TabBarItem from './TabBarItem';
 import TabBarIndicator, {
@@ -67,8 +73,8 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
       typeof route.accessibilityLabel === 'string'
         ? route.accessibilityLabel
         : typeof route.title === 'string'
-        ? route.title
-        : undefined,
+          ? route.title
+          : undefined,
     getTestID: ({ route }: Scene<T>) => route.testID,
     renderIndicator: (props: IndicatorProps<T>) => (
       <TabBarIndicator {...props} />
@@ -173,7 +179,10 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
     const maxDistance = tabBarWidth - layout.width;
     let result = Math.max(Math.min(value, maxDistance), 0);
 
-    return I18nManager.isRTL ? layout.width - result : result;
+    // in android and in RTL mode we should subtract the value from width
+    return I18nManager.isRTL && Platform.OS == 'android'
+      ? layout.width - result
+      : result;
   };
 
   _getScrollAmount = (props, i) => {
@@ -272,7 +281,10 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
     const { routes } = navigationState;
     const tabWidth = this._getTabWidth(this.props);
     const tabBarWidth = tabWidth * routes.length;
-    const translateX = Animated.multiply(this.state.scrollAmount, -1);
+    const translateX = Animated.multiply(
+      this.state.scrollAmount,
+      Platform.OS == 'ios' ? 1 : -1
+    );
 
     return (
       <Animated.View style={[styles.tabBar, style]}>

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -73,8 +73,8 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
       typeof route.accessibilityLabel === 'string'
         ? route.accessibilityLabel
         : typeof route.title === 'string'
-          ? route.title
-          : undefined,
+        ? route.title
+        : undefined,
     getTestID: ({ route }: Scene<T>) => route.testID,
     renderIndicator: (props: IndicatorProps<T>) => (
       <TabBarIndicator {...props} />

--- a/src/TabBarIndicator.js
+++ b/src/TabBarIndicator.js
@@ -10,7 +10,7 @@ export type Props<T> = {|
   ...SceneRendererProps,
   navigationState: NavigationState<T>,
   width: number,
-  scrollEnabled: boolean,
+  scrollEnabled?: boolean,
   style?: ViewStyleProp,
 |};
 

--- a/src/TabBarIndicator.js
+++ b/src/TabBarIndicator.js
@@ -14,18 +14,28 @@ export type Props<T> = {|
 |};
 
 export default function TabBarIndicator<T: Route>(props: Props<T>) {
-  const { width, position, navigationState, style } = props;
+  const {
+    width,
+    position,
+    navigationState,
+    style,
+    layout,
+    scrollEnabled,
+  } = props;
   const { routes } = navigationState;
-  const translateX = Animated.multiply(
+  const translateX = Animated.add(
     Animated.multiply(
-      Animated.interpolate(position, {
-        inputRange: [0, routes.length - 1],
-        outputRange: [0, routes.length - 1],
-        extrapolate: 'clamp',
-      }),
-      width
+      Animated.multiply(
+        Animated.interpolate(position, {
+          inputRange: [0, routes.length - 1],
+          outputRange: [0, routes.length - 1],
+          extrapolate: 'clamp',
+        }),
+        width
+      ),
+      I18nManager.isRTL ? -1 : 1
     ),
-    I18nManager.isRTL ? -1 : 1
+    I18nManager.isRTL && scrollEnabled ? layout.width : 0
   );
 
   return (

--- a/src/TabBarIndicator.js
+++ b/src/TabBarIndicator.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import * as React from 'react';
-import { StyleSheet, I18nManager } from 'react-native';
+import { StyleSheet, I18nManager, Platform } from 'react-native';
 import Animated from 'react-native-reanimated';
 import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type { Route, SceneRendererProps, NavigationState } from './types';
@@ -10,6 +10,7 @@ export type Props<T> = {|
   ...SceneRendererProps,
   navigationState: NavigationState<T>,
   width: number,
+  scrollEnabled: boolean,
   style?: ViewStyleProp,
 |};
 
@@ -35,7 +36,9 @@ export default function TabBarIndicator<T: Route>(props: Props<T>) {
       ),
       I18nManager.isRTL ? -1 : 1
     ),
-    I18nManager.isRTL && scrollEnabled ? layout.width : 0
+    I18nManager.isRTL && scrollEnabled && Platform.OS == 'android'
+      ? layout.width
+      : 0
   );
 
   return (


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
Tabbar with scrollEnabled not working properly in RTL mode.
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

- [x] scroll to correct tab 
- [x] move the indicator to the correct location
- [x] add platform specific. as this problem differs in Android and iOS.
### Test plan
use in RTL mode.
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
