### PR TITLE
fix: Touchable* onPress not working on ScrollView composition

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -486,7 +486,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
                   pressColor={this.props.pressColor}
                   pressOpacity={this.props.pressOpacity}
                   delayPressIn={0}
-                  onPress={() => this._handleTabPress({ route })}
+                  onPressIn={() => this._handleTabPress({ route })}
                   onLongPress={() => this._handleTabLongPress({ route })}
                   style={tabContainerStyle}
                 >

--- a/src/TouchableItem.js
+++ b/src/TouchableItem.js
@@ -13,7 +13,7 @@ import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet
 const LOLLIPOP = 21;
 
 type Props = {
-  onPress: () => mixed,
+  onPressIn: () => mixed,
   delayPressIn?: number,
   borderless?: boolean,
   pressColor?: string,
@@ -24,7 +24,7 @@ type Props = {
 
 export default class TouchableItem extends React.Component<Props> {
   static propTypes = {
-    onPress: PropTypes.func.isRequired,
+    onPressIn: PropTypes.func.isRequired,
     delayPressIn: PropTypes.number,
     borderless: PropTypes.bool,
     pressColor: PropTypes.string,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->
fix: Touchable* onPress not working on ScrollView composition

### Motivation
fix the issuse:  https://github.com/facebook/react-native/issues/10822

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
