### PR TITLE
feat: export extra animation options for Pager

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,22 @@ Callback which is called when the swipe gesture starts, i.e. the user touches th
 
 Callback which is called when the swipe gesture ends, i.e. the user lifts their finger from the screen after the swipe gesture.
 
+##### `timingConfig`
+
+Configuration object for the timing animation which occurs when tapping on tabs. Supported properties are:
+
+- `duration` (`number`)
+
+##### `springConfig`
+
+Configuration object for the spring animation which occurs after swiping. Supported properties are:
+
+- `damping` (`number`)
+- `mass` (`number`)
+- `stiffness` (`number`)
+- `restSpeedThreshold` (`number`)
+- `restDisplacementThreshold` (`number`)
+
 ##### `initialLayout`
 
 Object containing the initial height and width of the screens. Passing this will improve the initial rendering performance. For most apps, this is a good default:

--- a/src/Pager.js
+++ b/src/Pager.js
@@ -79,6 +79,20 @@ const DIRECTION_RIGHT = -1;
 const SWIPE_DISTANCE_MINIMUM = 20;
 const SWIPE_DISTANCE_MULTIPLIER = 1 / 1.75;
 
+const SPRING_CONFIG = {
+  damping: 30,
+  mass: 1,
+  stiffness: 200,
+  overshootClamping: true,
+  restSpeedThreshold: 0.001,
+  restDisplacementThreshold: 0.001,
+};
+
+const TIMING_CONFIG = {
+  duration: 250,
+  easing: Easing.out(Easing.cubic),
+};
+
 export default class Pager<T: Route> extends React.Component<Props<T>> {
   static defaultProps = {
     swipeVelocityThreshold: 1200,
@@ -140,27 +154,43 @@ export default class Pager<T: Route> extends React.Component<Props<T>> {
     if (prevProps.springConfig !== this.props.springConfig) {
       const { springConfig } = this.props;
 
-      springConfig.damping !== undefined &&
-        this._springConfig.damping.setValue(springConfig.damping);
-      springConfig.mass !== undefined &&
-        this._springConfig.mass.setValue(springConfig.mass);
-      springConfig.stiffness !== undefined &&
-        this._springConfig.stiffness.setValue(springConfig.stiffness);
-      springConfig.restSpeedThreshold !== undefined &&
-        this._springConfig.restSpeedThreshold.setValue(
-          springConfig.restSpeedThreshold
-        );
-      springConfig.restDisplacementThreshold !== undefined &&
-        this._springConfig.restDisplacementThreshold.setValue(
-          springConfig.restDisplacementThreshold
-        );
+      this._springConfig.damping.setValue(
+        springConfig.damping !== undefined
+          ? springConfig.damping
+          : SPRING_CONFIG.damping
+      );
+
+      this._springConfig.mass.setValue(
+        springConfig.mass !== undefined ? springConfig.mass : SPRING_CONFIG.mass
+      );
+
+      this._springConfig.stiffness.setValue(
+        springConfig.stiffness !== undefined
+          ? springConfig.stiffness
+          : SPRING_CONFIG.stiffness
+      );
+
+      this._springConfig.restSpeedThreshold.setValue(
+        springConfig.restSpeedThreshold !== undefined
+          ? springConfig.restSpeedThreshold
+          : SPRING_CONFIG.restSpeedThreshold
+      );
+
+      this._springConfig.restDisplacementThreshold.setValue(
+        springConfig.restDisplacementThreshold !== undefined
+          ? springConfig.restDisplacementThreshold
+          : SPRING_CONFIG.restDisplacementThreshold
+      );
     }
 
     if (prevProps.timingConfig !== this.props.timingConfig) {
       const { timingConfig } = this.props;
 
-      timingConfig.duration !== undefined &&
-        this._timingConfig.duration.setValue(timingConfig.duration);
+      this._timingConfig.duration.setValue(
+        timingConfig.duration !== undefined
+          ? timingConfig.duration
+          : TIMING_CONFIG.duration
+      );
     }
   }
 
@@ -207,38 +237,36 @@ export default class Pager<T: Route> extends React.Component<Props<T>> {
     damping: new Value(
       this.props.springConfig.damping !== undefined
         ? this.props.springConfig.damping
-        : 30
+        : SPRING_CONFIG.damping
     ),
     mass: new Value(
       this.props.springConfig.mass !== undefined
         ? this.props.springConfig.mass
-        : 1
+        : SPRING_CONFIG.mass
     ),
     stiffness: new Value(
       this.props.springConfig.stiffness !== undefined
         ? this.props.springConfig.stiffness
-        : 200
+        : SPRING_CONFIG.stiffness
     ),
     restSpeedThreshold: new Value(
       this.props.springConfig.restSpeedThreshold !== undefined
         ? this.props.springConfig.restSpeedThreshold
-        : 0.001
+        : SPRING_CONFIG.restSpeedThreshold
     ),
     restDisplacementThreshold: new Value(
       this.props.springConfig.restDisplacementThreshold !== undefined
         ? this.props.springConfig.restDisplacementThreshold
-        : 0.001
+        : SPRING_CONFIG.restDisplacementThreshold
     ),
-    overshootClamping: true,
   };
 
   _timingConfig = {
     duration: new Value(
       this.props.timingConfig.duration !== undefined
         ? this.props.timingConfig.duration
-        : 250
+        : TIMING_CONFIG.duration
     ),
-    easing: Easing.out(Easing.cubic),
   };
 
   // The reason for using this value instead of simply passing `this._velocity`
@@ -361,14 +389,14 @@ export default class Pager<T: Route> extends React.Component<Props<T>> {
           spring(
             this._clock,
             { ...state, velocity: this._initialVelocityForSpring },
-            { ...this._springConfig, toValue }
+            { ...SPRING_CONFIG, ...this._springConfig, toValue }
           ),
         ],
         // Otherwise use a timing animation for faster switching
         timing(
           this._clock,
           { ...state, frameTime },
-          { ...this._timingConfig, toValue }
+          { ...TIMING_CONFIG, ...this._timingConfig, toValue }
         )
       ),
       cond(state.finished, [

--- a/src/Pager.js
+++ b/src/Pager.js
@@ -96,6 +96,8 @@ const TIMING_CONFIG = {
 export default class Pager<T: Route> extends React.Component<Props<T>> {
   static defaultProps = {
     swipeVelocityThreshold: 1200,
+    extraSpringConfig: {},
+    extraTimingConfig: {},
   };
 
   componentDidUpdate(prevProps: Props<T>) {
@@ -283,6 +285,8 @@ export default class Pager<T: Route> extends React.Component<Props<T>> {
       finished: new Value(FALSE),
     };
 
+    const { extraTimingConfig, extraSpringConfig } = this.props;
+
     return block([
       cond(clockRunning(this._clock), NOOP, [
         // Animation wasn't running before
@@ -310,14 +314,14 @@ export default class Pager<T: Route> extends React.Component<Props<T>> {
           spring(
             this._clock,
             { ...state, velocity: this._initialVelocityForSpring },
-            { ...SPRING_CONFIG, toValue }
+            { ...SPRING_CONFIG, ...extraSpringConfig, toValue }
           ),
         ],
         // Otherwise use a timing animation for faster switching
         timing(
           this._clock,
           { ...state, frameTime },
-          { ...TIMING_CONFIG, toValue }
+          { ...TIMING_CONFIG, ...extraTimingConfig, toValue }
         )
       ),
       cond(state.finished, [

--- a/src/TabView.js
+++ b/src/TabView.js
@@ -53,6 +53,8 @@ export default class TabView<T: Route> extends React.Component<
     swipeEnabled: true,
     lazy: false,
     removeClippedSubviews: false,
+    springConfig: {},
+    timingConfig: {},
   };
 
   state = {
@@ -94,6 +96,8 @@ export default class TabView<T: Route> extends React.Component<
       swipeEnabled,
       swipeDistanceThreshold,
       swipeVelocityThreshold,
+      timingConfig,
+      springConfig,
       tabBarPosition,
       renderTabBar,
       renderScene,
@@ -112,6 +116,8 @@ export default class TabView<T: Route> extends React.Component<
           swipeEnabled={swipeEnabled}
           swipeDistanceThreshold={swipeDistanceThreshold}
           swipeVelocityThreshold={swipeVelocityThreshold}
+          timingConfig={timingConfig}
+          springConfig={springConfig}
           onSwipeStart={onSwipeStart}
           onSwipeEnd={onSwipeEnd}
           onIndexChange={this._jumpToIndex}

--- a/src/types.js
+++ b/src/types.js
@@ -41,6 +41,6 @@ export type PagerCommonProps = {|
   swipeVelocityThreshold?: number,
   onSwipeStart?: () => mixed,
   onSwipeEnd?: () => mixed,
-  extraSpringConfig?: Object,
-  extraTimingConfig?: Object,
+  springConfig?: Object,
+  timingConfig?: Object,
 |};

--- a/src/types.js
+++ b/src/types.js
@@ -41,6 +41,15 @@ export type PagerCommonProps = {|
   swipeVelocityThreshold?: number,
   onSwipeStart?: () => mixed,
   onSwipeEnd?: () => mixed,
-  springConfig?: Object,
-  timingConfig?: Object,
+  springConfig?: {|
+    damping?: number,
+    mass?: number,
+    stiffness?: number,
+    overshootClamping?: number,
+    restSpeedThreshold?: number,
+    restDisplacementThreshold?: number,
+  |},
+  timingConfig?: {|
+    duration?: number,
+  |},
 |};

--- a/src/types.js
+++ b/src/types.js
@@ -41,15 +41,14 @@ export type PagerCommonProps = {|
   swipeVelocityThreshold?: number,
   onSwipeStart?: () => mixed,
   onSwipeEnd?: () => mixed,
-  springConfig?: {|
+  springConfig: {|
     damping?: number,
     mass?: number,
     stiffness?: number,
-    overshootClamping?: number,
     restSpeedThreshold?: number,
     restDisplacementThreshold?: number,
   |},
-  timingConfig?: {|
+  timingConfig: {|
     duration?: number,
   |},
 |};

--- a/src/types.js
+++ b/src/types.js
@@ -41,4 +41,6 @@ export type PagerCommonProps = {|
   swipeVelocityThreshold?: number,
   onSwipeStart?: () => mixed,
   onSwipeEnd?: () => mixed,
+  extraSpringConfig?: Object,
+  extraTimingConfig?: Object,
 |};


### PR DESCRIPTION
### Motivation

Sometimes I suppose a user might want to define own behavior of timing of spring and I want to make it possible with this PR

### Test plan

Add some config (e.g. `extraSpringConfig`) to `Pager`.