### PR TITLE
feat: add dynamic tab width support

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -19,6 +19,7 @@ import TabBarIconExample from './TabBarIconExample';
 import CustomIndicatorExample from './CustomIndicatorExample';
 import CustomTabBarExample from './CustomTabBarExample';
 import CoverflowExample from './CoverflowExample';
+import DynamicWidthTabBarExample from './DynamicWidthTabBarExample';
 
 type State = {
   title: string;
@@ -44,6 +45,7 @@ const EXAMPLE_COMPONENTS: ExampleComponentType[] = [
   CustomIndicatorExample,
   CustomTabBarExample,
   CoverflowExample,
+  DynamicWidthTabBarExample,
 ];
 
 const KeepAwake = () => {

--- a/example/src/DynamicWidthTabBarExample.js
+++ b/example/src/DynamicWidthTabBarExample.js
@@ -1,0 +1,89 @@
+/* @flow */
+
+import * as React from 'react';
+import { StyleSheet } from 'react-native';
+import {
+  TabView,
+  TabBar,
+  SceneMap,
+  type NavigationState,
+} from 'react-native-tab-view';
+import Article from './Shared/Article';
+import Albums from './Shared/Albums';
+import Chat from './Shared/Chat';
+import Contacts from './Shared/Contacts';
+
+type State = NavigationState<{
+  key: string,
+  title: string,
+}>;
+
+export default class DynamicWidthTabBarExample extends React.Component<
+  *,
+  State
+> {
+  static title = 'Dynamic width tab bar';
+  static backgroundColor = '#3f51b5';
+  static appbarElevation = 0;
+
+  state = {
+    index: 1,
+    routes: [
+      { key: 'article', title: 'Article' },
+      { key: 'contacts', title: 'Contacts' },
+      { key: 'albums', title: 'Albums' },
+      { key: 'chat', title: 'Chat' },
+      { key: 'longTitle', title: 'long long long title' },
+      { key: 'mediumTitle', title: 'medium title' },
+    ],
+  };
+
+  _handleIndexChange = index =>
+    this.setState({
+      index,
+    });
+
+  _renderTabBar = props => (
+    <TabBar
+      {...props}
+      dynamicWidth
+      scrollEnabled
+      indicatorStyle={styles.indicator}
+      style={styles.tabbar}
+      labelStyle={styles.label}
+    />
+  );
+
+  _renderScene = SceneMap({
+    albums: Albums,
+    contacts: Contacts,
+    article: Article,
+    chat: Chat,
+    longTitle: Article,
+    mediumTitle: Article,
+  });
+
+  render() {
+    return (
+      <TabView
+        style={this.props.style}
+        navigationState={this.state}
+        renderScene={this._renderScene}
+        renderTabBar={this._renderTabBar}
+        onIndexChange={this._handleIndexChange}
+      />
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  tabbar: {
+    backgroundColor: '#3f51b5',
+  },
+  indicator: {
+    backgroundColor: '#ffeb3b',
+  },
+  label: {
+    fontWeight: '400',
+  },
+});

--- a/example/src/DynamicWidthTabBarExample.tsx
+++ b/example/src/DynamicWidthTabBarExample.tsx
@@ -1,12 +1,11 @@
-/* @flow */
-
 import * as React from 'react';
 import { StyleSheet } from 'react-native';
 import {
   TabView,
   TabBar,
   SceneMap,
-  type NavigationState,
+  NavigationState,
+  SceneRendererProps,
 } from 'react-native-tab-view';
 import Article from './Shared/Article';
 import Albums from './Shared/Albums';
@@ -14,12 +13,12 @@ import Chat from './Shared/Chat';
 import Contacts from './Shared/Contacts';
 
 type State = NavigationState<{
-  key: string,
-  title: string,
+  key: string;
+  title: string;
 }>;
 
 export default class DynamicWidthTabBarExample extends React.Component<
-  *,
+  {},
   State
 > {
   static title = 'Dynamic width tab bar';
@@ -38,12 +37,14 @@ export default class DynamicWidthTabBarExample extends React.Component<
     ],
   };
 
-  _handleIndexChange = index =>
+  private handleIndexChange = (index: number) =>
     this.setState({
       index,
     });
 
-  _renderTabBar = props => (
+  private renderTabBar = (
+    props: SceneRendererProps & { navigationState: State }
+  ) => (
     <TabBar
       {...props}
       dynamicWidth
@@ -54,7 +55,7 @@ export default class DynamicWidthTabBarExample extends React.Component<
     />
   );
 
-  _renderScene = SceneMap({
+  private renderScene = SceneMap({
     albums: Albums,
     contacts: Contacts,
     article: Article,
@@ -66,11 +67,10 @@ export default class DynamicWidthTabBarExample extends React.Component<
   render() {
     return (
       <TabView
-        style={this.props.style}
         navigationState={this.state}
-        renderScene={this._renderScene}
-        renderTabBar={this._renderTabBar}
-        onIndexChange={this._handleIndexChange}
+        renderScene={this.renderScene}
+        renderTabBar={this.renderTabBar}
+        onIndexChange={this.handleIndexChange}
       />
     );
   }

--- a/src/TabBarIndicator.tsx
+++ b/src/TabBarIndicator.tsx
@@ -8,55 +8,101 @@ import { Route, SceneRendererProps, NavigationState } from './types';
 export type Props<T extends Route> = SceneRendererProps & {
   dynamicWidth?: boolean;
   navigationState: NavigationState<T>;
+  tabWidths: number[];
   width: number;
   style?: StyleProp<ViewStyle>;
 };
 
 const { max, min, multiply } = Animated;
 
-export default class TabBarIndicator<T extends Route> extends React.Component<
-  Props<T>
-> {
+export default class TabBarIndicator<
+  T extends Route
+> extends React.PureComponent<Props<T>> {
   private getTranslateX = memoize(
-    (position: Animated.Node<number>, routes: Route[], width: number) =>
-      // TODO use dyanmic width to change translateX
-      multiply(
-        max(min(position, routes.length - 1), 0),
-        width * (I18nManager.isRTL ? -1 : 1)
-      )
-  );
-
-  private getScaleX = memoize(
-    (dynamicWidth: boolean, position: Animated.Node<number>, routes: Route[], tabWidths: number[]) => {
+    (
+      position: Animated.Node<number>,
+      routes: Route[],
+      tabWidths: number[],
+      width: number,
+      dynamicWidth?: boolean
+    ) => {
       if (dynamicWidth) {
         let inputRange: number[] = [];
         let outputRange: number[] = [];
-        routes.forEach((route: Route, i: number) => {
+        let totalWidth = 0;
+        routes.forEach((_route: Route, i: number) => {
+          if (i !== 0) {
+            totalWidth += tabWidths[i - 1];
+          }
+          inputRange.push(i);
+          outputRange.push(totalWidth + tabWidths[i] * 0.5);
+        });
+
+        return Animated.interpolate(position, {
+          inputRange,
+          outputRange,
+        });
+      }
+      return multiply(
+        max(min(position, routes.length - 1), 0),
+        width * (I18nManager.isRTL ? -1 : 1)
+      );
+    }
+  );
+
+  private getScaleX = memoize(
+    (
+      position: Animated.Node<number>,
+      routes: Route[],
+      tabWidths: number[],
+      dynamicWidth?: boolean
+    ) => {
+      if (dynamicWidth) {
+        let inputRange: number[] = [];
+        let outputRange: number[] = [];
+        routes.forEach((_route: Route, i: number) => {
           inputRange.push(i);
           outputRange.push(tabWidths[i]);
         });
         return Animated.interpolate(position, {
           inputRange,
           outputRange,
-          extrapolate: 'clamp',
         });
       }
       return 1;
     }
-  )
+  );
+
+  private getStyle = memoize((routes: Route[], dynamicWidth?: boolean) =>
+    dynamicWidth ? { width: 1 } : { width: `${100 / routes.length}%` }
+  );
 
   render() {
-    const { dynamicWidth, width, position, navigationState, tabWidths, style } = this.props;
+    const {
+      dynamicWidth,
+      width,
+      position,
+      navigationState,
+      tabWidths,
+      style,
+    } = this.props;
     const { routes } = navigationState;
 
-    const translateX = this.getTranslateX(position, routes, width);
-    const scaleX = this.getScaleX(dynamicWidth, position, routes, tabWidths);
+    const translateX = this.getTranslateX(
+      position,
+      routes,
+      tabWidths,
+      width,
+      dynamicWidth
+    );
+    const scaleX = this.getScaleX(position, routes, tabWidths, dynamicWidth);
+    const dynamicStyle = this.getStyle(routes, dynamicWidth);
 
     return (
       <Animated.View
         style={[
           styles.indicator,
-          { width: `${100 / routes.length}%` },
+          dynamicStyle,
           // If layout is not available, use `left` property for positioning the indicator
           // This avoids rendering delay until we are able to calculate translateX
           width
@@ -79,104 +125,3 @@ const styles = StyleSheet.create({
     height: 2,
   },
 });
-
-
-// /* @flow */
-//
-// import * as React from 'react';
-// import { StyleSheet, I18nManager } from 'react-native';
-// import Animated from 'react-native-reanimated';
-// import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
-// import type { Route, SceneRendererProps, NavigationState } from './types';
-//
-// export type Props<T> = {|
-//   ...SceneRendererProps,
-//   dynamicWidth?: boolean,
-//   navigationState: NavigationState<T>,
-//   style?: ViewStyleProp,
-//   tabWidths: number[],
-//   width: number,
-//   |};
-//
-// export default function TabBarIndicator<T: Route>(props: Props<T>) {
-//   const {
-//     dynamicWidth,
-//     tabWidths,
-//     width,
-//     position,
-//     navigationState,
-//     style,
-//   } = props;
-//   const { routes } = navigationState;
-//
-//   let translateX = null;
-//   let scaleX = 1;
-//   let dynamicStyle = { width: `${100 / routes.length}%` };
-//
-//   if (dynamicWidth) {
-//     let inputRange = [];
-//     let translateOutputRange = [];
-//     let scaleOutputRange = [];
-//     let totalWidth = 0;
-//     routes.forEach((route: Route, i: number) => {
-//       if (i !== 0) {
-//         totalWidth += tabWidths[i - 1];
-//       }
-//       inputRange.push(i);
-//       translateOutputRange.push(totalWidth + tabWidths[i] * 0.5);
-//       scaleOutputRange.push(tabWidths[i]);
-//     });
-//
-//     translateX = Animated.interpolate(position, {
-//       inputRange,
-//       outputRange: translateOutputRange,
-//       extrapolate: 'clamp',
-//     });
-//
-//     scaleX = Animated.interpolate(position, {
-//       inputRange,
-//       outputRange: scaleOutputRange,
-//       extrapolate: 'clamp',
-//     });
-//     dynamicStyle = { width: 1 };
-//   } else {
-//     translateX = Animated.multiply(
-//       Animated.interpolate(position, {
-//         inputRange: [0, routes.length - 1],
-//         outputRange: [0, routes.length - 1],
-//         extrapolate: 'clamp',
-//       }),
-//       width
-//     );
-//   }
-//
-//   translateX = Animated.multiply(translateX, I18nManager.isRTL ? -1 : 1);
-//
-//   return (
-//     <Animated.View
-//       style={[
-//         styles.indicator,
-//         dynamicStyle,
-//         // If layout is not available, use `left` property for positioning the indicator
-//         // This avoids rendering delay until we are able to calculate translateX
-//         width
-//           ? { transform: [{ translateX }, { scaleX }] }
-//           : { left: `${(100 / routes.length) * navigationState.index}%` },
-//         style,
-//       ]}
-//     />
-//   );
-// }
-//
-// const styles = StyleSheet.create({
-//   indicator: {
-//     backgroundColor: '#ffeb3b',
-//     position: 'absolute',
-//     left: 0,
-//     bottom: 0,
-//     right: 0,
-//     height: 2,
-//   },
-// });
-
-

--- a/src/TabBarIndicator.tsx
+++ b/src/TabBarIndicator.tsx
@@ -6,6 +6,7 @@ import memoize from './memoize';
 import { Route, SceneRendererProps, NavigationState } from './types';
 
 export type Props<T extends Route> = SceneRendererProps & {
+  dynamicWidth?: boolean;
   navigationState: NavigationState<T>;
   width: number;
   style?: StyleProp<ViewStyle>;
@@ -18,17 +19,38 @@ export default class TabBarIndicator<T extends Route> extends React.Component<
 > {
   private getTranslateX = memoize(
     (position: Animated.Node<number>, routes: Route[], width: number) =>
+      // TODO use dyanmic width to change translateX
       multiply(
         max(min(position, routes.length - 1), 0),
         width * (I18nManager.isRTL ? -1 : 1)
       )
   );
 
+  private getScaleX = memoize(
+    (dynamicWidth: boolean, position: Animated.Node<number>, routes: Route[], tabWidths: number[]) => {
+      if (dynamicWidth) {
+        let inputRange: number[] = [];
+        let outputRange: number[] = [];
+        routes.forEach((route: Route, i: number) => {
+          inputRange.push(i);
+          outputRange.push(tabWidths[i]);
+        });
+        return Animated.interpolate(position, {
+          inputRange,
+          outputRange,
+          extrapolate: 'clamp',
+        });
+      }
+      return 1;
+    }
+  )
+
   render() {
-    const { width, position, navigationState, style } = this.props;
+    const { dynamicWidth, width, position, navigationState, tabWidths, style } = this.props;
     const { routes } = navigationState;
 
     const translateX = this.getTranslateX(position, routes, width);
+    const scaleX = this.getScaleX(dynamicWidth, position, routes, tabWidths);
 
     return (
       <Animated.View
@@ -38,7 +60,7 @@ export default class TabBarIndicator<T extends Route> extends React.Component<
           // If layout is not available, use `left` property for positioning the indicator
           // This avoids rendering delay until we are able to calculate translateX
           width
-            ? { transform: [{ translateX }] as any }
+            ? { transform: [{ translateX }, { scaleX }] as any }
             : { left: `${(100 / routes.length) * navigationState.index}%` },
           style,
         ]}
@@ -57,3 +79,104 @@ const styles = StyleSheet.create({
     height: 2,
   },
 });
+
+
+// /* @flow */
+//
+// import * as React from 'react';
+// import { StyleSheet, I18nManager } from 'react-native';
+// import Animated from 'react-native-reanimated';
+// import type { ViewStyleProp } from 'react-native/Libraries/StyleSheet/StyleSheet';
+// import type { Route, SceneRendererProps, NavigationState } from './types';
+//
+// export type Props<T> = {|
+//   ...SceneRendererProps,
+//   dynamicWidth?: boolean,
+//   navigationState: NavigationState<T>,
+//   style?: ViewStyleProp,
+//   tabWidths: number[],
+//   width: number,
+//   |};
+//
+// export default function TabBarIndicator<T: Route>(props: Props<T>) {
+//   const {
+//     dynamicWidth,
+//     tabWidths,
+//     width,
+//     position,
+//     navigationState,
+//     style,
+//   } = props;
+//   const { routes } = navigationState;
+//
+//   let translateX = null;
+//   let scaleX = 1;
+//   let dynamicStyle = { width: `${100 / routes.length}%` };
+//
+//   if (dynamicWidth) {
+//     let inputRange = [];
+//     let translateOutputRange = [];
+//     let scaleOutputRange = [];
+//     let totalWidth = 0;
+//     routes.forEach((route: Route, i: number) => {
+//       if (i !== 0) {
+//         totalWidth += tabWidths[i - 1];
+//       }
+//       inputRange.push(i);
+//       translateOutputRange.push(totalWidth + tabWidths[i] * 0.5);
+//       scaleOutputRange.push(tabWidths[i]);
+//     });
+//
+//     translateX = Animated.interpolate(position, {
+//       inputRange,
+//       outputRange: translateOutputRange,
+//       extrapolate: 'clamp',
+//     });
+//
+//     scaleX = Animated.interpolate(position, {
+//       inputRange,
+//       outputRange: scaleOutputRange,
+//       extrapolate: 'clamp',
+//     });
+//     dynamicStyle = { width: 1 };
+//   } else {
+//     translateX = Animated.multiply(
+//       Animated.interpolate(position, {
+//         inputRange: [0, routes.length - 1],
+//         outputRange: [0, routes.length - 1],
+//         extrapolate: 'clamp',
+//       }),
+//       width
+//     );
+//   }
+//
+//   translateX = Animated.multiply(translateX, I18nManager.isRTL ? -1 : 1);
+//
+//   return (
+//     <Animated.View
+//       style={[
+//         styles.indicator,
+//         dynamicStyle,
+//         // If layout is not available, use `left` property for positioning the indicator
+//         // This avoids rendering delay until we are able to calculate translateX
+//         width
+//           ? { transform: [{ translateX }, { scaleX }] }
+//           : { left: `${(100 / routes.length) * navigationState.index}%` },
+//         style,
+//       ]}
+//     />
+//   );
+// }
+//
+// const styles = StyleSheet.create({
+//   indicator: {
+//     backgroundColor: '#ffeb3b',
+//     position: 'absolute',
+//     left: 0,
+//     bottom: 0,
+//     right: 0,
+//     height: 2,
+//   },
+// });
+
+

--- a/src/TabBarItem.tsx
+++ b/src/TabBarItem.tsx
@@ -12,6 +12,7 @@ import Animated from 'react-native-reanimated';
 import memoize from './memoize';
 
 type Props<T extends Route> = {
+  dynamicWidth?: boolean;
   position: Animated.Node<number>;
   route: T;
   navigationState: NavigationState<T>;
@@ -78,6 +79,7 @@ export default class TabBarItem<T extends Route> extends React.Component<
 
   render() {
     const {
+      dynamicWidth,
       route,
       position,
       navigationState,
@@ -202,7 +204,7 @@ export default class TabBarItem<T extends Route> extends React.Component<
       scrollEnabled === true;
 
     const tabContainerStyle: ViewStyle = {};
-    const itemStyle = isWidthSet ? { width: tabWidth } : null;
+    const itemStyle = isWidthSet && !dynamicWidth ? { width: tabWidth } : null;
 
     if (tabStyle && typeof tabStyle.flex === 'number') {
       tabContainerStyle.flex = tabStyle.flex;

--- a/src/TabBarItem.tsx
+++ b/src/TabBarItem.tsx
@@ -3,6 +3,7 @@ import {
   StyleSheet,
   View,
   StyleProp,
+  LayoutChangeEvent,
   TextStyle,
   ViewStyle,
 } from 'react-native';
@@ -36,6 +37,7 @@ type Props<T extends Route> = {
     color: string;
   }) => React.ReactNode;
   renderBadge?: (scene: Scene<T>) => React.ReactNode;
+  onLayout: (event: LayoutChangeEvent) => void;
   onPress: () => void;
   onLongPress: () => void;
   tabWidth: number;
@@ -46,7 +48,7 @@ type Props<T extends Route> = {
 const DEFAULT_ACTIVE_COLOR = 'rgba(255, 255, 255, 1)';
 const DEFAULT_INACTIVE_COLOR = 'rgba(255, 255, 255, 0.7)';
 
-export default class TabBarItem<T extends Route> extends React.Component<
+export default class TabBarItem<T extends Route> extends React.PureComponent<
   Props<T>
 > {
   private getActiveOpacity = memoize(
@@ -64,18 +66,20 @@ export default class TabBarItem<T extends Route> extends React.Component<
     }
   );
 
-  private getInactiveOpacity = memoize((position, routes, tabIndex) => {
-    if (routes.length > 1) {
-      const inputRange = routes.map((_: Route, i: number) => i);
+  private getInactiveOpacity = memoize(
+    (position: Animated.Node<number>, routes: Route[], tabIndex: number) => {
+      if (routes.length > 1) {
+        const inputRange = routes.map((_: Route, i: number) => i);
 
-      return Animated.interpolate(position, {
-        inputRange,
-        outputRange: inputRange.map((i: number) => (i === tabIndex ? 0 : 1)),
-      });
-    } else {
-      return 0;
+        return Animated.interpolate(position, {
+          inputRange,
+          outputRange: inputRange.map((i: number) => (i === tabIndex ? 0 : 1)),
+        });
+      } else {
+        return 0;
+      }
     }
-  });
+  );
 
   render() {
     const {
@@ -98,6 +102,7 @@ export default class TabBarItem<T extends Route> extends React.Component<
       labelStyle,
       style,
       tabWidth,
+      onLayout,
       onPress,
       onLongPress,
     } = this.props;
@@ -236,6 +241,7 @@ export default class TabBarItem<T extends Route> extends React.Component<
         pressColor={pressColor}
         pressOpacity={pressOpacity}
         delayPressIn={0}
+        onLayout={onLayout}
         onPress={onPress}
         onLongPress={onLongPress}
         style={tabContainerStyle}


### PR DESCRIPTION
### Motivation

There is currently no support for tabs that have a variable width. This is a common design and seems to be something the community wants  (https://github.com/react-native-community/react-native-tab-view/issues/356).

Credit to @jaitd for the initial related PR (https://github.com/react-native-community/react-native-tab-view/pull/544)

### Test plan

Checked with the example app and tested on my production app. I can publish it to npm to create a snack if it's necessary.
