### PR TITLE
fix: remove tabBar shadow

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -376,13 +376,6 @@ const styles = StyleSheet.create({
   },
   tabBar: {
     backgroundColor: '#2196f3',
-    elevation: 4,
-    shadowColor: 'black',
-    shadowOpacity: 0.1,
-    shadowRadius: StyleSheet.hairlineWidth,
-    shadowOffset: {
-      height: StyleSheet.hairlineWidth,
-    },
     zIndex: 1,
   },
   tabContent: {


### PR DESCRIPTION
### Motivation

There's a default shadow on the parent `Animated.View` which caused a shadow on the text rendered from the `renderLabel` prop. In my opinion, there should be no shadow by default and can be added during implementation.

### Test plan

trivial change
