### PR TITLE
fix: setting initial tab behaviour for iOS RN 0.59.x

### DIFF
--- a/src/PagerScroll.js
+++ b/src/PagerScroll.js
@@ -150,6 +150,7 @@ export default class PagerScroll<T: *> extends React.Component<
         keyboardDismissMode="on-drag"
         keyboardShouldPersistTaps="always"
         overScrollMode="never"
+        scrollToOverflowEnabled
         scrollEnabled={this.props.swipeEnabled}
         automaticallyAdjustContentInsets={false}
         bounces={false}


### PR DESCRIPTION
Fix an issue where the initial tab is ignored on iOS and React Native 0.59.x when the initial tab is not the first tab in the set.

This uses the newly introduced [scrollToOverflowEnabled prop](https://github.com/facebook/react-native/commit/e3ac329).

It seems counterintuitive to have this along with `overScrollMode="never"` but `overScrollMode` really controls the ability to scroll past the ends of a `ScrollView`, while `scrollToOverflowEnabled` allows us to manually `scrollTo()` an arbitrary position out of bounds of the `ScrollView`.

I'm unsure of the underlying change in RN0.59.x that caused this, but it seems that the ScrollView hasn't completed layout when the `_setInitialPage()` is called, so it's unable to scroll to a non-zero x value.

Should address https://github.com/react-navigation/react-navigation/issues/5754

May also close this issue: #743