### PR TITLE
fix: try to improve the performance

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -215,8 +215,6 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
       layout,
       navigationState,
       jumpTo,
-      addListener,
-      removeListener,
       scrollEnabled,
       bounces,
       getAccessibilityLabel,
@@ -259,8 +257,6 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
             layout,
             navigationState,
             jumpTo,
-            addListener,
-            removeListener,
             width: tabWidth,
             style: indicatorStyle,
           })}

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -95,12 +95,6 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
     };
   }
 
-  componentDidMount() {
-    if (this.props.scrollEnabled) {
-      this.props.addListener('position', this._adjustScroll);
-    }
-  }
-
   componentDidUpdate(prevProps: Props<T>) {
     if (
       prevProps.navigationState.routes.length !==
@@ -113,18 +107,6 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
     ) {
       this._resetScroll(this.props.navigationState.index);
     }
-
-    if (prevProps.scrollEnabled !== this.props.scrollEnabled) {
-      if (this.props.scrollEnabled) {
-        this.props.addListener('position', this._adjustScroll);
-      } else {
-        this.props.removeListener('position', this._adjustScroll);
-      }
-    }
-  }
-
-  componentWillUnmount() {
-    this.props.removeListener('position', this._adjustScroll);
   }
 
   _scrollView: ?ScrollView;
@@ -182,21 +164,6 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
     const scrollAmount = centerDistance - layout.width / 2;
 
     return this._normalizeScrollValue(props, scrollAmount);
-  };
-
-  _adjustScroll = (value: number) => {
-    if (this.props.scrollEnabled) {
-      cancelAnimationFrame(this._scrollResetCallback);
-
-      this._scrollView &&
-        this._scrollView.scrollTo({
-          x: this._normalizeScrollValue(
-            this.props,
-            this._getScrollAmount(this.props, value)
-          ),
-          animated: false,
-        });
-    }
   };
 
   _resetScroll = (value: number, animated = true) => {

--- a/src/TabBarIndicator.js
+++ b/src/TabBarIndicator.js
@@ -17,15 +17,12 @@ export default function TabBarIndicator<T: Route>(props: Props<T>) {
   const { width, position, navigationState, style } = props;
   const { routes } = navigationState;
   const translateX = Animated.multiply(
-    Animated.multiply(
-      Animated.interpolate(position, {
-        inputRange: [0, routes.length - 1],
-        outputRange: [0, routes.length - 1],
-        extrapolate: 'clamp',
-      }),
-      width
-    ),
-    I18nManager.isRTL ? -1 : 1
+    Animated.interpolate(position, {
+      inputRange: [0, routes.length - 1],
+      outputRange: [0, routes.length - 1],
+      extrapolate: 'clamp',
+    }),
+    width * (I18nManager.isRTL ? -1 : 1)
   );
 
   return (

--- a/src/TabView.js
+++ b/src/TabView.js
@@ -130,8 +130,6 @@ export default class TabView<T: Route> extends React.Component<
               position,
               layout,
               jumpTo,
-              addListener,
-              removeListener,
             };
 
             return (
@@ -146,6 +144,8 @@ export default class TabView<T: Route> extends React.Component<
                     return (
                       <SceneView
                         {...sceneRendererProps}
+                        addListener={addListener}
+                        removeListener={removeListener}
                         key={route.key}
                         index={i}
                         lazy={lazy}

--- a/src/types.js
+++ b/src/types.js
@@ -30,8 +30,11 @@ export type SceneRendererProps = {|
   layout: Layout,
   position: Animated.Node<number>,
   jumpTo: (key: string) => void,
-  addListener: (type: 'position', listener: Listener) => void,
-  removeListener: (type: 'position', listener: Listener) => void,
+|};
+
+export type EventEmitterProps = {|
+  addListener: (type: 'enter', listener: Listener) => void,
+  removeListener: (type: 'enter', listener: Listener) => void,
 |};
 
 export type PagerCommonProps = {|


### PR DESCRIPTION
This commit aims to throttle the events from reanimated to avoid overloading JS thread. It changes a few things:
- Due to the throttling, we cannot get the same scroll as you swipe effect on scrollable tab bar, which is probably better as this didn't work smoothly on lower end devices
- We now call onIndexChange as soon as you lift your finger rather than waiting for the animation to finish, which seems to work okay
- Due to throttling, empty page for lazy loaded tabs is more pronounced, but this can be work around by providing a placeholder component

Closes #700, #716
