### PR TITLE
refactor: drop position listeners in favor of enter listeners

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -215,8 +215,6 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
       layout,
       navigationState,
       jumpTo,
-      addListener,
-      removeListener,
       scrollEnabled,
       bounces,
       getAccessibilityLabel,
@@ -259,8 +257,6 @@ export default class TabBar<T: Route> extends React.Component<Props<T>, State> {
             layout,
             navigationState,
             jumpTo,
-            addListener,
-            removeListener,
             width: tabWidth,
             style: indicatorStyle,
           })}

--- a/src/TabBarIndicator.js
+++ b/src/TabBarIndicator.js
@@ -17,15 +17,12 @@ export default function TabBarIndicator<T: Route>(props: Props<T>) {
   const { width, position, navigationState, style } = props;
   const { routes } = navigationState;
   const translateX = Animated.multiply(
-    Animated.multiply(
-      Animated.interpolate(position, {
-        inputRange: [0, routes.length - 1],
-        outputRange: [0, routes.length - 1],
-        extrapolate: 'clamp',
-      }),
-      width
-    ),
-    I18nManager.isRTL ? -1 : 1
+    Animated.interpolate(position, {
+      inputRange: [0, routes.length - 1],
+      outputRange: [0, routes.length - 1],
+      extrapolate: 'clamp',
+    }),
+    width * (I18nManager.isRTL ? -1 : 1)
   );
 
   return (

--- a/src/TabView.js
+++ b/src/TabView.js
@@ -130,8 +130,6 @@ export default class TabView<T: Route> extends React.Component<
               position,
               layout,
               jumpTo,
-              addListener,
-              removeListener,
             };
 
             return (
@@ -146,6 +144,8 @@ export default class TabView<T: Route> extends React.Component<
                     return (
                       <SceneView
                         {...sceneRendererProps}
+                        addListener={addListener}
+                        removeListener={removeListener}
                         key={route.key}
                         index={i}
                         lazy={lazy}

--- a/src/types.js
+++ b/src/types.js
@@ -30,8 +30,11 @@ export type SceneRendererProps = {|
   layout: Layout,
   position: Animated.Node<number>,
   jumpTo: (key: string) => void,
-  addListener: (type: 'position', listener: Listener) => void,
-  removeListener: (type: 'position', listener: Listener) => void,
+|};
+
+export type EventEmitterProps = {|
+  addListener: (type: 'enter', listener: Listener) => void,
+  removeListener: (type: 'enter', listener: Listener) => void,
 |};
 
 export type PagerCommonProps = {|


### PR DESCRIPTION
This drops the undocumented position listener which can cause perf issues by overloading the bridge in favor of a enter listener which can be used for lazy loading