### PR TITLE
feat: Add distance treshold prop for lazy - `lazyThreshold`

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,10 @@ Boolean indicating whether to lazily render the scenes. By default all scenes ar
 
 When you enable `lazy`, the unfocused screens will usually take some time to render when they come into focus. You can use the `renderLazyPlaceholder` prop to customize what the user sees during this short period.
 
+##### `preloadDistance`
+
+When `lazy` is enabled this number can be used to specify the pre-load distance. This value defaults to `0` which means lazy pages are loaded when they become active.
+
 ##### `renderLazyPlaceholder`
 
 Callback which returns a custom React Element to render for routes that haven't been rendered yet. Receives an object containing the route as the argument. The `lazy` prop also needs to be enabled.

--- a/src/SceneView.tsx
+++ b/src/SceneView.tsx
@@ -11,6 +11,7 @@ type Props<T extends Route> = SceneRendererProps &
   EventEmitterProps & {
     navigationState: NavigationState<T>;
     lazy: boolean;
+    preloadDistance: number;
     index: number;
     children: (props: { loading: boolean }) => React.ReactNode;
     style?: StyleProp<ViewStyle>;
@@ -25,7 +26,11 @@ export default class SceneView<T extends Route> extends React.Component<
   State
 > {
   static getDerivedStateFromProps(props: Props<Route>, state: State) {
-    if (state.loading && props.navigationState.index === props.index) {
+    if (
+      state.loading &&
+      Math.abs(props.navigationState.index - props.index) <=
+        props.preloadDistance
+    ) {
       // Always render the route when it becomes focused
       return { loading: false };
     }
@@ -34,7 +39,9 @@ export default class SceneView<T extends Route> extends React.Component<
   }
 
   state = {
-    loading: this.props.navigationState.index !== this.props.index,
+    loading:
+      Math.abs(this.props.navigationState.index - this.props.index) >
+      this.props.preloadDistance,
   };
 
   componentDidMount() {

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -37,6 +37,7 @@ type Props<T extends Route> = PagerCommonProps & {
   tabBarPosition: 'top' | 'bottom';
   initialLayout?: { width?: number; height?: number };
   lazy: boolean;
+  preloadDistance: number;
   removeClippedSubviews?: boolean;
   sceneContainerStyle?: StyleProp<ViewStyle>;
   style?: StyleProp<ViewStyle>;
@@ -60,6 +61,7 @@ export default class TabView<T extends Route> extends React.Component<
     keyboardDismissMode: 'on-drag',
     swipeEnabled: true,
     lazy: false,
+    preloadDistance: 0,
     removeClippedSubviews: false,
     springConfig: {},
     timingConfig: {},
@@ -101,6 +103,7 @@ export default class TabView<T extends Route> extends React.Component<
       onSwipeEnd,
       navigationState,
       lazy,
+      preloadDistance,
       removeClippedSubviews,
       keyboardDismissMode,
       swipeEnabled,
@@ -166,6 +169,7 @@ export default class TabView<T extends Route> extends React.Component<
                         key={route.key}
                         index={i}
                         lazy={lazy}
+                        preloadDistance={preloadDistance}
                         navigationState={navigationState}
                         style={sceneContainerStyle}
                       >


### PR DESCRIPTION
When `lazy` is enabled this number can be used to specify the pre-load distance. This value defaults to `0` which means lazy pages are loaded when they become active.

### Motivation

Allows one to reduce white content flash on tab-change when `lazy` prop is used.

### Test plan

Manually tested that lazy tabs are loaded based on `lazyThreshold` value.