### PR TITLE
fix: memoize animated nodes to improve performance

### DIFF
--- a/src/memoize.js
+++ b/src/memoize.js
@@ -1,0 +1,35 @@
+/* @flow */
+
+export default function memoize<Result, Deps: any[]>(
+  callback: (...deps: Deps) => Result
+) {
+  let previous: ?Deps;
+  let result: ?Result;
+
+  return (...dependencies: Deps) => {
+    let hasChanged = false;
+
+    if (previous) {
+      if (previous.length !== dependencies.length) {
+        hasChanged = true;
+      } else {
+        for (let i = 0; i < previous.length; i++) {
+          if (previous[i] !== dependencies[i]) {
+            hasChanged = true;
+            break;
+          }
+        }
+      }
+    } else {
+      hasChanged = true;
+    }
+
+    previous = dependencies;
+
+    if (hasChanged || result === undefined) {
+      result = callback(...dependencies);
+    }
+
+    return result;
+  };
+}


### PR DESCRIPTION
Currently the animated nodes used for styles are re-created in render, which means that reanimated does a lot of expensive work detaching and reattaching them. Due to this, the framerate of the JS thread goes down to 0 FPS even on high-end devices when switching tabs quickly.

This PR implements memoization for the animated nodes so they are only recreated when necessary. On low-end devices, this keeps the JS frame rate around 12+ FPS on low-end devices and 40+ on high-end devices.

Related to #720