### PR TITLE
fix: don't consider velocity and gesture distance if gesture didn't end

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint --ext .js,.ts,.tsx .",
     "release": "release-it",
     "example": "yarn --cwd example",
-    "bootstrap": "yarn && yarn example",
+    "bootstrap": "yarn example && yarn",
     "prepare": "bob build"
   },
   "publishConfig": {


### PR DESCRIPTION
previously, when gesture wasn't active, we checked if the gesture exceeded the minimum threshold (this was due to activeOffsetX not being respected on Android),
- if yes, we calculate the next position based on gesture distance or velocity
- if no, we transition to what the value of index was

this addressed 2 cases: the first condition would trigger when a gesture was performed, the second one will trigger if the index changed due to other means such as state update.
this check was mistakenly removed in e7f832c

the new code checked for `State.END`, which resulted in the tab switch due to state update not working at times. this is because the `gestureState` value is different when a gesture was cancelled, e.g. due to a vertical gesture or focus on an input element.

closes #806, closes #809