### PR TITLE
feat: improve keyboard handling during tab change

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,8 @@ Boolean indicating whether to remove invisible views (such as unfocused screens)
 
 String indicating whether the keyboard gets dismissed in response to a drag gesture. Possible values are:
 
-- `'on-drag'` (default): the keyboard is dismissed when a drag begins.
+- `'auto'` (default): the keyboard is dismissed when the index changes.
+- `'on-drag'`: the keyboard is dismissed when a drag begins.
 - `'none'`: drags do not dismiss the keyboard.
 
 ##### `swipeEnabled`

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -58,7 +58,7 @@ export default class TabView<T extends Route> extends React.Component<
       <TabBar {...props} />
     ),
     renderLazyPlaceholder: () => null,
-    keyboardDismissMode: 'on-drag',
+    keyboardDismissMode: 'auto',
     swipeEnabled: true,
     lazy: false,
     lazyPreloadDistance: 0,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -37,7 +37,7 @@ export type EventEmitterProps = {
 };
 
 export type PagerCommonProps = {
-  keyboardDismissMode: 'none' | 'on-drag';
+  keyboardDismissMode: 'none' | 'on-drag' | 'auto';
   swipeEnabled: boolean;
   swipeVelocityImpact?: number;
   onSwipeStart?: () => void;


### PR DESCRIPTION
Currently the keyboard is dismissed only when a swipe gesture starts. This commit changes the behaviour so that:

- Keyboard is dismissed if the tab index changes
- When a gesture begines, keyboard is dismissed, but if the index didn't change at end of the gesture, it's restored

This is closer to iOS native behaviour and is based on previous work by [@skevy](https://github.com/skevy) in react-navgation:
https://github.com/react-navigation/react-navigation/pull/3951

The old behaviour is left as the 'on-drag' option for backward compatibility.

<img src="https://user-images.githubusercontent.com/1174278/60164921-b8d58880-97fe-11e9-9a56-4e0929871065.gif" width="300px" height="auto">
