### PR TITLE
Change logic of switching tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Boolean indicating whether to enable swipe gestures. Swipe gestures are enabled 
 
 ##### `swipeVelocityImpact`
 
-Determines how relevant is a velocity while calculating next position while swiping. Defaults to `0.01`.
+Determines how relevant is a velocity while calculating next position while swiping. Defaults to `0.2`.
 
 ##### `onSwipeStart`
 

--- a/src/Pager.tsx
+++ b/src/Pager.tsx
@@ -80,7 +80,7 @@ const DIRECTION_RIGHT = -1;
 
 const SWIPE_DISTANCE_MINIMUM = 20;
 
-const SWIPE_VELOCITY_IMPACT = 0.01;
+const SWIPE_VELOCITY_IMPACT = 0.2;
 
 const SPRING_CONFIG = {
   stiffness: 1000,
@@ -427,20 +427,9 @@ export default class Pager<T extends Route> extends React.Component<Props<T>> {
     },
   ]);
 
-  private velocitySignum = cond(
-    this.velocityX,
-    divide(abs(this.velocityX), this.velocityX),
-    0
-  );
-
   private extrapolatedPosition = add(
     this.gestureX,
-    multiply(
-      this.velocityX,
-      this.velocityX,
-      this.velocitySignum,
-      this.swipeVelocityImpact
-    )
+    multiply(this.velocityX, this.swipeVelocityImpact)
   );
 
   private translateX = block([
@@ -582,7 +571,7 @@ export default class Pager<T extends Route> extends React.Component<Props<T>> {
                   sub(
                     this.index,
                     cond(
-                      greaterThan(this.velocitySignum, 0),
+                      greaterThan(this.extrapolatedPosition, 0),
                       I18nManager.isRTL ? DIRECTION_RIGHT : DIRECTION_LEFT,
                       I18nManager.isRTL ? DIRECTION_LEFT : DIRECTION_RIGHT
                     )


### PR DESCRIPTION
## Motivation
It appears that previous logic was considering velocity in a too aggressive way. So I'd like to get rid of extra velocity multiplication. It should lead to more natural behavior. 


If it works, I'd like to move these changes to stack-view as well.  