### PR TITLE
 feat: support `width: 'auto'` in tabStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,8 @@ Boolean indicating whether the tab bar bounces when scrolling.
 
 Style to apply to the individual tab items in the tab bar.
 
+By default, all tab items take up the same pre-calculated width based on the width of the container. If you want them to take their original width, you can specify `width: 'auto'` in `tabStyle`.
+
 ##### `indicatorStyle`
 
 Style to apply to the active indicator.

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -15,6 +15,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import ScrollableTabBarExample from './ScrollableTabBarExample';
+import AutoWidthTabBarExample from './AutoWidthTabBarExample';
 import TabBarIconExample from './TabBarIconExample';
 import CustomIndicatorExample from './CustomIndicatorExample';
 import CustomTabBarExample from './CustomTabBarExample';
@@ -40,6 +41,7 @@ const PERSISTENCE_KEY = 'index_persistence';
 
 const EXAMPLE_COMPONENTS: ExampleComponentType[] = [
   ScrollableTabBarExample,
+  AutoWidthTabBarExample,
   TabBarIconExample,
   CustomIndicatorExample,
   CustomTabBarExample,
@@ -225,7 +227,6 @@ const styles = StyleSheet.create({
   },
   title: {
     flex: 1,
-    margin: 16,
     textAlign: Platform.OS === 'ios' ? 'center' : 'left',
     fontSize: 18,
     color: '#fff',

--- a/example/src/AutoWidthTabBarExample.tsx
+++ b/example/src/AutoWidthTabBarExample.tsx
@@ -17,11 +17,11 @@ type State = NavigationState<{
   title: string;
 }>;
 
-export default class ScrollableTabBarExample extends React.Component<
+export default class DynamicWidthTabBarExample extends React.Component<
   {},
   State
 > {
-  static title = 'Scrollable tab bar';
+  static title = 'Scrollable tab bar (auto width)';
   static backgroundColor = '#3f51b5';
   static appbarElevation = 0;
 
@@ -32,6 +32,8 @@ export default class ScrollableTabBarExample extends React.Component<
       { key: 'contacts', title: 'Contacts' },
       { key: 'albums', title: 'Albums' },
       { key: 'chat', title: 'Chat' },
+      { key: 'long', title: 'long long long title' },
+      { key: 'medium', title: 'medium title' },
     ],
   };
 
@@ -48,8 +50,8 @@ export default class ScrollableTabBarExample extends React.Component<
       scrollEnabled
       indicatorStyle={styles.indicator}
       style={styles.tabbar}
-      tabStyle={styles.tab}
       labelStyle={styles.label}
+      tabStyle={styles.tabStyle}
     />
   );
 
@@ -58,6 +60,8 @@ export default class ScrollableTabBarExample extends React.Component<
     contacts: Contacts,
     article: Article,
     chat: Chat,
+    long: Article,
+    medium: Article,
   });
 
   render() {
@@ -76,13 +80,13 @@ const styles = StyleSheet.create({
   tabbar: {
     backgroundColor: '#3f51b5',
   },
-  tab: {
-    width: 120,
-  },
   indicator: {
     backgroundColor: '#ffeb3b',
   },
   label: {
     fontWeight: '400',
+  },
+  tabStyle: {
+    width: 'auto',
   },
 });

--- a/example/src/CustomIndicatorExample.tsx
+++ b/example/src/CustomIndicatorExample.tsx
@@ -53,9 +53,12 @@ export default class CustomIndicatorExample extends React.Component<{}, State> {
     });
 
   private renderIndicator = (
-    props: SceneRendererProps & { navigationState: State; width: number }
+    props: SceneRendererProps & {
+      navigationState: State;
+      getTabWidth: (i: number) => number;
+    }
   ) => {
-    const { width, position, navigationState } = props;
+    const { position, navigationState, getTabWidth } = props;
     const inputRange = [
       0,
       0.48,
@@ -85,9 +88,10 @@ export default class CustomIndicatorExample extends React.Component<{}, State> {
 
     const translateX = Animated.interpolate(position, {
       inputRange: inputRange,
-      outputRange: inputRange.map(
-        x => Math.round(x) * width * (I18nManager.isRTL ? -1 : 1)
-      ),
+      outputRange: inputRange.map(x => {
+        const i = Math.round(x);
+        return i * getTabWidth(i) * (I18nManager.isRTL ? -1 : 1);
+      }),
     });
 
     const backgroundColor = Animated.interpolate(position, {

--- a/src/TabBarIndicator.tsx
+++ b/src/TabBarIndicator.tsx
@@ -1,45 +1,127 @@
 import * as React from 'react';
 import { StyleSheet, I18nManager, StyleProp, ViewStyle } from 'react-native';
-import Animated from 'react-native-reanimated';
+import Animated, { Easing } from 'react-native-reanimated';
 
 import memoize from './memoize';
 import { Route, SceneRendererProps, NavigationState } from './types';
 
+export type GetTabWidth = (index: number) => number;
+
 export type Props<T extends Route> = SceneRendererProps & {
   navigationState: NavigationState<T>;
-  width: number;
+  width: string;
   style?: StyleProp<ViewStyle>;
+  getTabWidth: GetTabWidth;
 };
 
-const { max, min, multiply } = Animated;
+const { multiply } = Animated;
 
 export default class TabBarIndicator<T extends Route> extends React.Component<
   Props<T>
 > {
+  componentDidMount() {
+    this.fadeInIndicator();
+  }
+
+  componentDidUpdate() {
+    this.fadeInIndicator();
+  }
+
+  private fadeInIndicator = () => {
+    const { navigationState, layout, width, getTabWidth } = this.props;
+
+    if (
+      !this.isIndicatorShown &&
+      width === 'auto' &&
+      layout.width &&
+      // We should fade-in the indicator when we have widths for all the tab items
+      navigationState.routes.every((_, i) => getTabWidth(i))
+    ) {
+      this.isIndicatorShown = true;
+
+      Animated.timing(this.opacity, {
+        duration: 150,
+        toValue: 1,
+        easing: Easing.in(Easing.linear),
+      }).start();
+    }
+  };
+
+  private isIndicatorShown = false;
+
+  private opacity = new Animated.Value(this.props.width === 'auto' ? 0 : 1);
+
   private getTranslateX = memoize(
-    (position: Animated.Node<number>, routes: Route[], width: number) =>
-      multiply(
-        max(min(position, routes.length - 1), 0),
-        width * (I18nManager.isRTL ? -1 : 1)
-      )
+    (
+      position: Animated.Node<number>,
+      routes: Route[],
+      getTabWidth: GetTabWidth
+    ) => {
+      const inputRange = routes.map((_, i) => i);
+
+      // every index contains widths at all previous indices
+      const outputRange = routes.reduce<number[]>((acc, _, i) => {
+        if (i === 0) return [0];
+        return [...acc, acc[i - 1] + getTabWidth(i - 1)];
+      }, []);
+
+      const transalteX = Animated.interpolate(position, {
+        inputRange,
+        outputRange,
+      });
+
+      return multiply(transalteX, I18nManager.isRTL ? -1 : 1);
+    }
+  );
+
+  private getWidth = memoize(
+    (
+      position: Animated.Node<number>,
+      routes: Route[],
+      getTabWidth: GetTabWidth
+    ) => {
+      const inputRange = routes.map((_, i) => i);
+      const outputRange = inputRange.map(getTabWidth);
+
+      return Animated.interpolate(position, {
+        inputRange,
+        outputRange,
+      });
+    }
   );
 
   render() {
-    const { layout, width, position, navigationState, style } = this.props;
+    const {
+      position,
+      navigationState,
+      getTabWidth,
+      width,
+      style,
+      layout,
+    } = this.props;
     const { routes } = navigationState;
 
-    const translateX = this.getTranslateX(position, routes, width);
+    const translateX =
+      routes.length > 1 ? this.getTranslateX(position, routes, getTabWidth) : 0;
+
+    const indicatorWidth =
+      width === 'auto'
+        ? routes.length > 1
+          ? this.getWidth(position, routes, getTabWidth)
+          : getTabWidth(0)
+        : width;
 
     return (
       <Animated.View
         style={[
           styles.indicator,
-          { width: `${100 / routes.length}%` },
           // If layout is not available, use `left` property for positioning the indicator
           // This avoids rendering delay until we are able to calculate translateX
+          { width: indicatorWidth },
           layout.width
             ? { transform: [{ translateX }] as any }
             : { left: `${(100 / routes.length) * navigationState.index}%` },
+          width === 'auto' ? { opacity: this.opacity } : null,
           style,
         ]}
       />

--- a/src/TabBarItem.tsx
+++ b/src/TabBarItem.tsx
@@ -3,6 +3,7 @@ import {
   StyleSheet,
   View,
   StyleProp,
+  LayoutChangeEvent,
   TextStyle,
   ViewStyle,
 } from 'react-native';
@@ -34,6 +35,7 @@ type Props<T extends Route> = {
     color: string;
   }) => React.ReactNode;
   renderBadge?: (scene: Scene<T>) => React.ReactNode;
+  onLayout?: (event: LayoutChangeEvent) => void;
   onPress: () => void;
   onLongPress: () => void;
   labelStyle?: StyleProp<TextStyle>;
@@ -92,6 +94,7 @@ export default class TabBarItem<T extends Route> extends React.Component<
       pressOpacity,
       labelStyle,
       style,
+      onLayout,
       onPress,
       onLongPress,
     } = this.props;
@@ -220,6 +223,7 @@ export default class TabBarItem<T extends Route> extends React.Component<
         pressColor={pressColor}
         pressOpacity={pressOpacity}
         delayPressIn={0}
+        onLayout={onLayout}
         onPress={onPress}
         onLongPress={onLongPress}
         style={tabContainerStyle}


### PR DESCRIPTION
The PR is based on #751 and #823 (thanks to @Taylor123 and @ankeetmaini)

The improvements include:

1. For tab bar with `width: 'auto'`, fade in the indicator when we have the layout. This avoids sometimes noticeable jump in the indicator.
1. Memoize the `getTabWidth` prop passed to `renderIndicator`. This makes sure that the animated nodes are memoized properly as well and fixes the issue with the width jumping at end of animation on Android.
1. Make sure we adjust the scroll value only after the layout is available. This fixes an issue where sometimes the scroll position is incorrect on initial load.
1. Fixed calculation of center distance so the correct tab is centered.
1. Minor tweak to how we store tab widths in state, use an object with route key as keys which should be more accurate when new tabs are added/removed and also easier to work with.
1. Minor change which avoids adding an `onLayout` listener if tab width isn't auto.