### PR TITLE
feat: add springVelocityScale effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,10 @@ Configuration object for the spring animation which occurs after swiping. Suppor
 
 ##### `initialLayout`
 
+Number for determining how meaningful is gesture velocity for calculating initial velocity of spring animation. Defaults to `0`.
+
+##### `initialLayout
+
 Object containing the initial height and width of the screens. Passing this will improve the initial rendering performance. For most apps, this is a good default:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Configuration object for the spring animation which occurs after swiping. Suppor
 - `restSpeedThreshold` (`number`)
 - `restDisplacementThreshold` (`number`)
 
-##### `initialLayout`
+##### `springVelocityScale`
 
 Number for determining how meaningful is gesture velocity for calculating initial velocity of spring animation. Defaults to `0`.
 

--- a/src/Pager.tsx
+++ b/src/Pager.tsx
@@ -142,7 +142,7 @@ export default class Pager<T extends Route> extends React.Component<Props<T>> {
 
     if (prevProps.swipeVelocityImpact !== swipeVelocityImpact) {
       this.swipeVelocityImpact.setValue(
-        swipeVelocityImpact != null
+        swipeVelocityImpact !== undefined
           ? swipeVelocityImpact
           : SWIPE_VELOCITY_IMPACT
       );
@@ -150,7 +150,7 @@ export default class Pager<T extends Route> extends React.Component<Props<T>> {
 
     if (prevProps.springVelocityScale !== springVelocityScale) {
       this.springVelocityScale.setValue(
-        springVelocityScale != null
+        springVelocityScale !== undefined
           ? springVelocityScale
           : SPRING_VELOCITY_SCALE
       );

--- a/src/Pager.tsx
+++ b/src/Pager.tsx
@@ -101,6 +101,7 @@ const TIMING_CONFIG = {
 export default class Pager<T extends Route> extends React.Component<Props<T>> {
   static defaultProps = {
     swipeVelocityImpact: SWIPE_VELOCITY_IMPACT,
+    springVelocityScale: SPRING_VELOCITY_SCALE,
   };
 
   componentDidUpdate(prevProps: Props<T>) {
@@ -108,6 +109,7 @@ export default class Pager<T extends Route> extends React.Component<Props<T>> {
       navigationState,
       layout,
       swipeVelocityImpact,
+      springVelocityScale,
       springConfig,
       timingConfig,
     } = this.props;
@@ -143,6 +145,14 @@ export default class Pager<T extends Route> extends React.Component<Props<T>> {
         swipeVelocityImpact != null
           ? swipeVelocityImpact
           : SWIPE_VELOCITY_IMPACT
+      );
+    }
+
+    if (prevProps.springVelocityScale !== springVelocityScale) {
+      this.springVelocityScale.setValue(
+        springVelocityScale != null
+          ? springVelocityScale
+          : SPRING_VELOCITY_SCALE
       );
     }
 
@@ -233,6 +243,10 @@ export default class Pager<T extends Route> extends React.Component<Props<T>> {
     this.props.swipeVelocityImpact || SWIPE_VELOCITY_IMPACT
   );
 
+  private springVelocityScale = new Value(
+    this.props.springVelocityScale || SPRING_VELOCITY_SCALE
+  );
+
   // The position value represent the position of the pager on a scale of 0 - routes.length-1
   // It is calculated based on the translate value and layout width
   // If we don't have the layout yet, we should return the current index
@@ -278,11 +292,6 @@ export default class Pager<T extends Route> extends React.Component<Props<T>> {
         : TIMING_CONFIG.duration
     ),
   };
-
-  private springVelocityScale =
-    this.props.springVelocityScale !== undefined
-      ? this.props.springVelocityScale
-      : SPRING_VELOCITY_SCALE;
 
   // The reason for using this value instead of simply passing `this._velocity`
   // into a spring animation is that we need to reverse it if we're using RTL mode.

--- a/src/Pager.tsx
+++ b/src/Pager.tsx
@@ -91,6 +91,8 @@ const SPRING_CONFIG = {
   restSpeedThreshold: 0.01,
 };
 
+const TOSS = 1;
+
 const TIMING_CONFIG = {
   duration: 200,
   easing: Easing.out(Easing.cubic),
@@ -277,6 +279,8 @@ export default class Pager<T extends Route> extends React.Component<Props<T>> {
     ),
   };
 
+  private toss = this.props.toss !== undefined ? this.props.toss : TOSS;
+
   // The reason for using this value instead of simply passing `this._velocity`
   // into a spring animation is that we need to reverse it if we're using RTL mode.
   // Also, it's not possible to pass multiplied value there, because
@@ -381,7 +385,6 @@ export default class Pager<T extends Route> extends React.Component<Props<T>> {
         set(state.time, 0),
         set(state.finished, FALSE),
         set(this.index, index),
-        startClock(this.clock),
       ]),
       cond(
         this.isSwipeGesture,
@@ -390,8 +393,14 @@ export default class Pager<T extends Route> extends React.Component<Props<T>> {
           cond(
             not(clockRunning(this.clock)),
             I18nManager.isRTL
-              ? set(this.initialVelocityForSpring, multiply(-1, this.velocityX))
-              : set(this.initialVelocityForSpring, this.velocityX)
+              ? set(
+                  this.initialVelocityForSpring,
+                  multiply(-1, this.velocityX, this.toss)
+                )
+              : set(
+                  this.initialVelocityForSpring,
+                  multiply(this.velocityX, this.toss)
+                )
           ),
           spring(
             this.clock,
@@ -406,6 +415,7 @@ export default class Pager<T extends Route> extends React.Component<Props<T>> {
           { ...TIMING_CONFIG, ...this.timingConfig, toValue }
         )
       ),
+      cond(not(clockRunning(this.clock)), startClock(this.clock)),
       cond(state.finished, [
         // Reset values
         set(this.isSwipeGesture, FALSE),

--- a/src/Pager.tsx
+++ b/src/Pager.tsx
@@ -91,7 +91,7 @@ const SPRING_CONFIG = {
   restSpeedThreshold: 0.01,
 };
 
-const TOSS = 1;
+const SPRING_VELOCITY_SCALE = 1;
 
 const TIMING_CONFIG = {
   duration: 200,
@@ -279,7 +279,10 @@ export default class Pager<T extends Route> extends React.Component<Props<T>> {
     ),
   };
 
-  private toss = this.props.toss !== undefined ? this.props.toss : TOSS;
+  private springVelocityScale =
+    this.props.springVelocityScale !== undefined
+      ? this.props.springVelocityScale
+      : SPRING_VELOCITY_SCALE;
 
   // The reason for using this value instead of simply passing `this._velocity`
   // into a spring animation is that we need to reverse it if we're using RTL mode.
@@ -395,11 +398,11 @@ export default class Pager<T extends Route> extends React.Component<Props<T>> {
             I18nManager.isRTL
               ? set(
                   this.initialVelocityForSpring,
-                  multiply(-1, this.velocityX, this.toss)
+                  multiply(-1, this.velocityX, this.springVelocityScale)
                 )
               : set(
                   this.initialVelocityForSpring,
-                  multiply(this.velocityX, this.toss)
+                  multiply(this.velocityX, this.springVelocityScale)
                 )
           ),
           spring(

--- a/src/Pager.tsx
+++ b/src/Pager.tsx
@@ -240,11 +240,15 @@ export default class Pager<T extends Route> extends React.Component<Props<T>> {
 
   // Determines how relevant is a velocity while calculating next position while swiping
   private swipeVelocityImpact = new Value(
-    this.props.swipeVelocityImpact || SWIPE_VELOCITY_IMPACT
+    this.props.swipeVelocityImpact !== undefined
+      ? this.props.swipeVelocityImpact
+      : SWIPE_VELOCITY_IMPACT
   );
 
   private springVelocityScale = new Value(
-    this.props.springVelocityScale || SPRING_VELOCITY_SCALE
+    this.props.springVelocityScale !== undefined
+      ? this.props.springVelocityScale
+      : SPRING_VELOCITY_SCALE
   );
 
   // The position value represent the position of the pager on a scale of 0 - routes.length-1

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -117,6 +117,7 @@ export default class TabView<T extends Route> extends React.Component<
       sceneContainerStyle,
       style,
       gestureHandlerProps,
+      toss,
     } = this.props;
     const { layout } = this.state;
 
@@ -133,6 +134,7 @@ export default class TabView<T extends Route> extends React.Component<
           onSwipeStart={onSwipeStart}
           onSwipeEnd={onSwipeEnd}
           onIndexChange={this.jumpToIndex}
+          toss={toss}
           removeClippedSubviews={removeClippedSubviews}
           gestureHandlerProps={gestureHandlerProps}
         >

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -117,7 +117,7 @@ export default class TabView<T extends Route> extends React.Component<
       sceneContainerStyle,
       style,
       gestureHandlerProps,
-      toss,
+      springVelocityScale,
     } = this.props;
     const { layout } = this.state;
 
@@ -134,7 +134,7 @@ export default class TabView<T extends Route> extends React.Component<
           onSwipeStart={onSwipeStart}
           onSwipeEnd={onSwipeEnd}
           onIndexChange={this.jumpToIndex}
-          toss={toss}
+          springVelocityScale={springVelocityScale}
           removeClippedSubviews={removeClippedSubviews}
           gestureHandlerProps={gestureHandlerProps}
         >

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -42,6 +42,7 @@ export type PagerCommonProps = {
   swipeVelocityImpact?: number;
   onSwipeStart?: () => void;
   onSwipeEnd?: () => void;
+  toss?: number;
   springConfig: {
     damping?: number;
     mass?: number;

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -42,7 +42,7 @@ export type PagerCommonProps = {
   swipeVelocityImpact?: number;
   onSwipeStart?: () => void;
   onSwipeEnd?: () => void;
-  toss?: number;
+  springVelocityScale?: number;
   springConfig: {
     damping?: number;
     mass?: number;


### PR DESCRIPTION
### Motivation

In this PR I add springVelocityScale parameter as a config of Pager. Toss defines how much velocity of gesture impacts on an initial velocity of Pager. Found it very useful in bottom sheet. 

Also, @christianbaroni asked me for doing it so here you are, Christian 😄 

However, while writing this code I figured out interesting bug in Pager which led to fact that initial velocity of spring was always zero. It happened bc previously velocity was set only if clock was not running. However few lines above we made similar check and if clock was not running... then we were starting it, so as the result there was no chance that in current state clock was not running. 
I fixed it by moving starting clock few lines below.

### Test plan
 You may add `springVelocityScale ={4}` param to `ScrollableTabBarExample`
