### PR TITLE
feat: be able to apply transform on tab indicator

### DIFF
--- a/src/TabBarIndicator.tsx
+++ b/src/TabBarIndicator.tsx
@@ -113,6 +113,8 @@ export default class TabBarIndicator<T extends Route> extends React.Component<
           : getTabWidth(0)
         : width;
 
+    //@ts-ignore
+    const { transform, ...styleRest } = style || {};
     return (
       <Animated.View
         style={[
@@ -121,10 +123,10 @@ export default class TabBarIndicator<T extends Route> extends React.Component<
           // This avoids rendering delay until we are able to calculate translateX
           { width: indicatorWidth },
           layout.width
-            ? { transform: [{ translateX }] as any }
+            ? { transform: [{ translateX }, ...(transform || [])] as any }
             : { left: `${(100 / routes.length) * navigationState.index}%` },
           width === 'auto' ? { opacity: this.opacity } : null,
-          style,
+          layout.width ? styleRest : style,
         ]}
       />
     );


### PR DESCRIPTION
This PR adds a possibility to apply custom transform on `TabBarIndicator`. 
Currently, when the user passes a `transform` prop it overrides internal `transform`, and built-in `translateX` doesn't work

<img width="334" alt="Zrzut ekranu 2019-09-20 o 19 19 48" src="https://user-images.githubusercontent.com/11561585/65357913-8cac8680-dbf8-11e9-9c3c-d99b38aab322.png">


### Motivation

There was a requirement in my project to have an indicator width less than tab width. I fount out, that the safest way do it was to use `scaleX`

### Test plan

In one of the examples in example app add 
```jsx
<TabBarIndicator
style={{
  transform: [{
    scaleX: 0.5
  }]
}} 
/>

And verify if both built-in translate and added scale work
```
