### PR TITLE
feat: add renderTouchable to TabBar

### DIFF
--- a/src/TabBar.tsx
+++ b/src/TabBar.tsx
@@ -11,7 +11,7 @@ import {
   Platform,
 } from 'react-native';
 import Animated from 'react-native-reanimated';
-import TabBarItem from './TabBarItem';
+import TabBarItem, { TouchableItemProps } from './TabBarItem';
 import TabBarIndicator, { Props as IndicatorProps } from './TabBarIndicator';
 import memoize from './memoize';
 import {
@@ -49,6 +49,7 @@ export type Props<T extends Route> = SceneRendererProps & {
   ) => React.ReactNode;
   renderBadge?: (scene: Scene<T>) => React.ReactNode;
   renderIndicator: (props: IndicatorProps<T>) => React.ReactNode;
+  renderTouchable?: (props: TouchableItemProps) => React.ReactNode;
   onTabPress?: (scene: Scene<T> & Event) => void;
   onTabLongPress?: (scene: Scene<T>) => void;
   tabStyle?: StyleProp<ViewStyle>;
@@ -310,6 +311,7 @@ export default class TabBar<T extends Route> extends React.Component<
       renderBadge,
       renderIcon,
       renderLabel,
+      renderTouchable,
       activeColor,
       inactiveColor,
       pressColor,
@@ -433,6 +435,7 @@ export default class TabBar<T extends Route> extends React.Component<
                 renderBadge={renderBadge}
                 renderIcon={renderIcon}
                 renderLabel={renderLabel}
+                renderTouchable={renderTouchable}
                 activeColor={activeColor}
                 inactiveColor={inactiveColor}
                 pressColor={pressColor}

--- a/src/TabBarItem.tsx
+++ b/src/TabBarItem.tsx
@@ -7,10 +7,12 @@ import {
   TextStyle,
   ViewStyle,
 } from 'react-native';
-import TouchableItem from './TouchableItem';
+import TouchableItem, { Props as TouchableItemProps } from './TouchableItem';
 import { Scene, Route, NavigationState } from './types';
 import Animated from 'react-native-reanimated';
 import memoize from './memoize';
+
+export type TouchableItemProps = TouchableItemProps;
 
 type Props<T extends Route> = {
   position: Animated.Node<number>;
@@ -35,6 +37,7 @@ type Props<T extends Route> = {
     color: string;
   }) => React.ReactNode;
   renderBadge?: (scene: Scene<T>) => React.ReactNode;
+  renderTouchable?: (props: TouchableItemProps) => React.ReactNode;
   onLayout?: (event: LayoutChangeEvent) => void;
   onPress: () => void;
   onLongPress: () => void;
@@ -84,6 +87,7 @@ export default class TabBarItem<T extends Route> extends React.Component<
       renderLabel: renderLabelPassed,
       renderIcon,
       renderBadge,
+      renderTouchable,
       getLabelText,
       getTestID,
       getAccessibilityLabel,
@@ -209,30 +213,36 @@ export default class TabBarItem<T extends Route> extends React.Component<
 
     const badge = renderBadge ? renderBadge(scene) : null;
 
-    return (
-      <TouchableItem
-        borderless
-        testID={getTestID(scene)}
-        accessible={getAccessible(scene)}
-        accessibilityLabel={accessibilityLabel}
-        accessibilityTraits={isFocused ? ['button', 'selected'] : 'button'}
-        accessibilityComponentType="button"
-        accessibilityRole="button"
-        accessibilityStates={isFocused ? ['selected'] : []}
-        pressColor={pressColor}
-        pressOpacity={pressOpacity}
-        delayPressIn={0}
-        onLayout={onLayout}
-        onPress={onPress}
-        onLongPress={onLongPress}
-        style={tabContainerStyle}
-      >
-        <View pointerEvents="none" style={[styles.item, tabStyle]}>
-          {icon}
-          {label}
-          {badge != null ? <View style={styles.badge}>{badge}</View> : null}
-        </View>
-      </TouchableItem>
+    const touchableChildren = (
+      <View pointerEvents="none" style={[styles.item, tabStyle]}>
+        {icon}
+        {label}
+        {badge != null ? <View style={styles.badge}>{badge}</View> : null}
+      </View>
+    );
+
+    const touchableProps: TouchableItemProps = {
+      borderless: true,
+      testID: getTestID(scene),
+      accessible: getAccessible(scene),
+      accessibilityLabel,
+      accessibilityTraits: isFocused ? ['button', 'selected'] : 'button',
+      accessibilityComponentType: 'button',
+      accessibilityRole: 'button',
+      accessibilityStates: isFocused ? ['selected'] : [],
+      pressColor,
+      pressOpacity,
+      delayPressIn: 0,
+      onLayout,
+      onPress,
+      onLongPress: onLongPress,
+      style: tabContainerStyle,
+    };
+
+    return renderTouchable != null ? (
+      renderTouchable({ ...touchableProps, children: touchableChildren })
+    ) : (
+      <TouchableItem {...touchableProps}>{touchableChildren}</TouchableItem>
     );
   }
 }

--- a/src/TouchableItem.tsx
+++ b/src/TouchableItem.tsx
@@ -9,12 +9,12 @@ import {
   ViewProps,
 } from 'react-native';
 
-type Props = ViewProps & {
+export type Props = ViewProps & {
   onPress: () => void;
   onLongPress?: () => void;
   delayPressIn?: number;
   borderless?: boolean;
-  pressColor: string;
+  pressColor?: string;
   pressOpacity?: number;
   children?: React.ReactNode;
   style?: StyleProp<ViewStyle>;
@@ -41,7 +41,10 @@ export default class TouchableItem extends React.Component<Props> {
       return (
         <TouchableNativeFeedback
           {...rest}
-          background={TouchableNativeFeedback.Ripple(pressColor, borderless)}
+          background={TouchableNativeFeedback.Ripple(
+            pressColor as string,
+            borderless
+          )}
         >
           <View style={style}>{React.Children.only(children)}</View>
         </TouchableNativeFeedback>


### PR DESCRIPTION
### Motivation

Allows for alternative Touchable implementation e.g. Touchable components from react-native-gesture-handler
fixes #884

### Test plan

Example usage
```javascript
import {
  SceneMap,
  TabView,
  TabBar,
} from "react-native-tab-view"
import React, { useState } from "react"
import { TouchableNativeFeedback, TouchableOpacity } from "react-native-gesture-handler"

const CustomTouchable = (props) => {
  const LOLLIPOP = 21;

  const {
    style,
    pressOpacity,
    pressColor,
    borderless,
    children,
    ...rest
  } = props;

  if (Platform.OS === 'android' && Platform.Version >= LOLLIPOP) {
    return (
      <TouchableNativeFeedback
        {...rest}
        background={TouchableNativeFeedback.Ripple(
          pressColor,
          borderless
        )}
      >
        <View style={{ flex: 1, style }}>{React.Children.only(children)}</View>
      </TouchableNativeFeedback>
    );
  } else {
    return (
      <TouchableOpacity {...rest} style={style} activeOpacity={pressOpacity}>
        {children}
      </TouchableOpacity>
    );
  }
}

const StyledTabBar = props => {
  return (
    <TabBar
      renderTouchable={CustomTouchable}
      activeColor={Colors.red}
      inactiveColor={Colors.lightGrey}
      {...props}
    />
  )
}

const Screen = () => {
  const [navigationState, setNavigationState] = useState({
    index: 0,
    routes: [
      { key: "screen1", title: "Screen 1" },
      { key: "screen2", title: "Screen 2" },
    ],
  })

  return (
      <TabView
        navigationState={navigationState}
        renderScene={SceneMap({
          screen1: Screen1,
          screen2: Screen2,
        })}
        renderTabBar={StyledTabBar}
        onIndexChange={index => {
          setNavigationState({ ...navigationState, index })
        }}
      />
  )
}
```