### PR TITLE
docs: update Quick Start example with 0 index state

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const SecondRoute = () => (
 const initialLayout = { width: Dimensions.get('window').width };
 
 export default function TabViewExample() {
-  const [index, setIndex] = React.useState(index);
+  const [index, setIndex] = React.useState(0);
   const [routes] = React.useState([
     { key: 'first', title: 'First' },
     { key: 'second', title: 'Second' },


### PR DESCRIPTION
The given example at [Quick Start](https://github.com/react-native-community/react-native-tab-view#quick-start) does not work because it's missing navigationState index.

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
A broken example is confusing for beginners.
### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
