### PR TITLE
feat: export TabBarIndicator

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,9 @@
 export { default as TabView, Props as TabViewProps } from './TabView';
 export { default as TabBar, Props as TabBarProps } from './TabBar';
+export {
+  default as TabBarIndicator,
+  Props as TabBarIndicatorProps,
+} from './TabBarIndicator';
 export { default as SceneMap } from './SceneMap';
 export { default as ScrollPager } from './ScrollPager';
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
Currently it’s possible to import `TabBar` and use the component as the tab bar in `renderTabBar`
```
import { TabBar } from 'react-native-tab-view';
 
...
 
<TabView
  renderTabBar={props => <TabBar {...props} />}
  ...
/>
```
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

Similarly it should also be possible to import `TabBarIndicator` so it can be used in `renderIndicator`.
```
import { TabBarIndicator } from 'react-native-tab-view';
 
...
 
<TabBar
  renderIndicator ={props => <TabBarIndicator {...props} />}
  ...
/>
```

I was attempting to modify the styles of the default indicator and realized that I couldn't import the component like this.
### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

For testing, ensure that the import statement doesn't introduce any errors.