### PR TITLE
Allow child to be clickable

### DIFF
--- a/src/TabBarItem.tsx
+++ b/src/TabBarItem.tsx
@@ -227,7 +227,7 @@ export default class TabBarItem<T extends Route> extends React.Component<
         onLongPress={onLongPress}
         style={tabContainerStyle}
       >
-        <View pointerEvents="none" style={[styles.item, tabStyle]}>
+        <View style={[styles.item, tabStyle]}>
           {icon}
           {label}
           {badge != null ? <View style={styles.badge}>{badge}</View> : null}


### PR DESCRIPTION
### Motivation
Allows touchable child be clickable, while not affecting parent clickability.

