### PR TITLE
Make `jumpToIndex` public

### DIFF
--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -79,7 +79,7 @@ export default class TabView<T extends Route> extends React.Component<
     layout: { width: 0, height: 0, ...this.props.initialLayout },
   };
 
-  private jumpToIndex = (index: number) => {
+  jumpToIndex = (index: number) => {
     if (index !== this.props.navigationState.index) {
       this.props.onIndexChange(index);
     }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

Sometimes, you may need to slide to the next/previous item from the component that is higher in hierarchy than `TabView`. By making `jumpToIndex` public, we get rid of TypeScript error when calling it by ref - `tabView.current.jumpToIndex(i + 1)`

### Test plan

Works perfectly 😉 
