### PR TITLE
fix: type export warning in webpack

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,18 @@
-export { default as TabView, Props as TabViewProps } from './TabView';
-export { default as TabBar, Props as TabBarProps } from './TabBar';
-export {
-  default as TabBarIndicator,
-  Props as TabBarIndicatorProps,
-} from './TabBarIndicator';
+import * as tv from './TabView';
+import * as tb from './TabBar';
+import * as tbi from './TabBarIndicator';
+import * as types from './types';
+
+// help babel to transpile the types correctly
+export type TabViewProps<T extends types.Route> = tv.Props<T>;
+export type TabBarProps<T extends types.Route> = tb.Props<T>;
+export type TabBarIndicatorProps<T extends types.Route> = tbi.Props<T>;
+export type Route = types.Route;
+export type NavigationState<T extends types.Route> = types.NavigationState<T>;
+export type SceneRendererProps = types.SceneRendererProps;
+
+export { default as TabView } from './TabView';
+export { default as TabBar } from './TabBar';
+export { default as TabBarIndicator } from './TabBarIndicator';
 export { default as SceneMap } from './SceneMap';
 export { default as ScrollPager } from './ScrollPager';
-
-export { Route, NavigationState, SceneRendererProps } from './types';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "esnext"
+    "target": "esnext",
+    "isolatedModules": true,
   }
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

fixed babel typescript transpile error for Props type exports (#969, #945):

```
./node_modules/react-native-tab-view/lib/module/index.js
"export 'Props' (reexported as 'TabBarProps') was not found in './TabBar'
```

This is mainly caused by a well-known babel typescript transform limit that it can not tell types from values, see babel/babel#8361

 Change summary
- added `isolatedModules:true` in tsconfig.json so typescript will prevent such problem going forward
- refactor the `index.ts` to explicitly export Props as types.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

the `example` now worked

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
