### PR TITLE
fix: teach ScrollPager how to call onIndexChange

### DIFF
--- a/src/ScrollPager.tsx
+++ b/src/ScrollPager.tsx
@@ -4,7 +4,7 @@ import Animated from 'react-native-reanimated';
 import { Props } from './Pager';
 import { Route, Listener } from './types';
 
-const { event, divide, Value } = Animated;
+const { event, divide, onChange, cond, eq, round, call, Value } = Animated;
 
 type State = {
   initialOffset: { x: number; y: number };
@@ -136,6 +136,7 @@ export default class ScrollPager<T extends Route> extends React.Component<
       onSwipeStart,
       onSwipeEnd,
       overscroll,
+      onIndexChange,
       navigationState,
     } = this.props;
 
@@ -188,6 +189,16 @@ export default class ScrollPager<T extends Route> extends React.Component<
           ref={this.scrollViewRef}
         >
           {children}
+          <Animated.Code
+            exec={onChange(
+              this.relativePosition,
+              cond(eq(round(this.relativePosition), this.relativePosition), [
+                call([this.relativePosition], ([relativePosition]) =>
+                  onIndexChange(relativePosition)
+                ),
+              ])
+            )}
+          />
         </Animated.ScrollView>
       ),
     });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

cc @osdnk @satya164 

### Motivation

I opened #993 after observing that `onIndexChange` does not appear to work when passing `renderPager={props => ScrollPager {...props } />`. This component only calls `onIndexChange` when it's `jumpTo` API method is called, but not simply as a result of scrolling within the inner `ScrollView`.

### Test plan

I have no idea but it doesn't look like there are any existing tests so I imagine this isn't a blocker. I would love to know how to test `ScrollView` interactions though so if anyone has insight please share.
