### PR TITLE
fix: fix scrollbars being always visible in TabBar on web

### DIFF
--- a/src/TabBar.tsx
+++ b/src/TabBar.tsx
@@ -472,7 +472,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   scroll: {
-    overflow: 'hidden',
+    overflow: Platform.select({ default: 'scroll', web: undefined }),
   },
   tabBar: {
     backgroundColor: '#2196f3',

--- a/src/TabBar.tsx
+++ b/src/TabBar.tsx
@@ -472,7 +472,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   scroll: {
-    overflow: 'scroll',
+    overflow: 'hidden',
   },
   tabBar: {
     backgroundColor: '#2196f3',


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
On windows there are useless scrollbar around TabBar (react-native-web). I don't know what is the purpose of `overflow:scroll` here but changing to `overflow:hidden` fixes the issue. on mac it is reproducible if you set _show scroll bars_ to _Always_ in _Settings -> General_ Which this is the default behaviour on windows
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
1. Create a simple tab view
2. You should see the scrollbars
 
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
![image](https://user-images.githubusercontent.com/61647712/78425029-f23cfd80-7686-11ea-8fe8-620ce890f78e.png)
