### PR TITLE
feat: add `renderTabBarItem` prop to `TabBar`

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,10 @@ Function which takes an object with the current route, focused status and color 
 />
 ```
 
+##### `renderTabBarItem`
+
+Function which takes a `TabBarItemProps` object and returns a custom React Element to be used as a tab button.
+
 ##### `renderIndicator`
 
 Function which takes an object with the current route and returns a custom React Element to be used as a tab indicator.

--- a/src/TabBarItem.tsx
+++ b/src/TabBarItem.tsx
@@ -12,7 +12,7 @@ import { Scene, Route, NavigationState } from './types';
 import Animated from 'react-native-reanimated';
 import memoize from './memoize';
 
-type Props<T extends Route> = {
+export type Props<T extends Route> = {
   position: Animated.Node<number>;
   route: T;
   navigationState: NavigationState<T>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,10 @@ export type { Props as TabViewProps } from './TabView';
 export { default as TabBarIndicator } from './TabBarIndicator';
 export type { Props as TabBarIndicatorProps } from './TabBarIndicator';
 
+export type { Props as TabBarItemProps } from './TabBarItem';
+
+export { default as TouchableItem } from './TouchableItem';
+
 export { default as SceneMap } from './SceneMap';
 export { default as ScrollPager } from './ScrollPager';
 


### PR DESCRIPTION
### Motivation

We want to use `react-native-tab-view` and its' `TabBar` without replacing it, but want to replace `TabBarItem`, as we are required to do a few changes to the tab labels, that can't be achieved by just passing `labelStyle` to it. (For example, our tab animations will be changing other attribute than `opacity` which is currently set by native `TabBarItem`.)

This simple change lets replace the TabBarItem component if somebody needs to.