### PR TITLE
fix: call onIndexChange only if scrollview was dragged

### DIFF
--- a/src/ScrollPager.tsx
+++ b/src/ScrollPager.tsx
@@ -58,17 +58,18 @@ export default class ScrollPager<T extends Route> extends React.Component<
     y: 0,
   };
 
+  private wasTouched: boolean = false;
+
   // InteractionHandle to handle tasks around animations
   private interactionHandle: number | null = null;
 
   private scrollViewRef = React.createRef<Animated.ScrollView>();
 
   private jumpTo = (key: string) => {
+    this.wasTouched = false;
     const { navigationState, keyboardDismissMode, onIndexChange } = this.props;
 
-    const index = navigationState.routes.findIndex(
-      (route) => route.key === key
-    );
+    const index = navigationState.routes.findIndex(route => route.key === key);
 
     if (navigationState.index === index) {
       this.scrollTo(index * this.props.layout.width);
@@ -148,6 +149,7 @@ export default class ScrollPager<T extends Route> extends React.Component<
     };
 
     const handleSwipeEnd = () => {
+      this.wasTouched = true;
       onSwipeEnd?.();
       if (this.interactionHandle !== null) {
         InteractionManager.clearInteractionHandle(this.interactionHandle);
@@ -159,7 +161,7 @@ export default class ScrollPager<T extends Route> extends React.Component<
       addListener: this.addListener,
       removeListener: this.removeListener,
       jumpTo: this.jumpTo,
-      render: (children) => (
+      render: children => (
         <Animated.ScrollView
           pagingEnabled
           directionalLockEnabled
@@ -192,14 +194,17 @@ export default class ScrollPager<T extends Route> extends React.Component<
         >
           {children}
           <Animated.Code
-            exec={onChange(
-              this.relativePosition,
+            exec={onChange(this.relativePosition, [
               cond(eq(round(this.relativePosition), this.relativePosition), [
-                call([this.relativePosition], ([relativePosition]) =>
-                  onIndexChange(relativePosition)
-                ),
-              ])
-            )}
+                call([this.relativePosition], ([relativePosition]) => {
+                  if (this.wasTouched) {
+                    onIndexChange(relativePosition);
+                    this.wasTouched = false;
+                  }
+                }),
+              ]),
+              call([this.relativePosition], console.log),
+            ])}
           />
         </Animated.ScrollView>
       ),

--- a/src/ScrollPager.tsx
+++ b/src/ScrollPager.tsx
@@ -69,7 +69,9 @@ export default class ScrollPager<T extends Route> extends React.Component<
     this.wasTouched = false;
     const { navigationState, keyboardDismissMode, onIndexChange } = this.props;
 
-    const index = navigationState.routes.findIndex(route => route.key === key);
+    const index = navigationState.routes.findIndex(
+      (route) => route.key === key
+    );
 
     if (navigationState.index === index) {
       this.scrollTo(index * this.props.layout.width);
@@ -161,7 +163,7 @@ export default class ScrollPager<T extends Route> extends React.Component<
       addListener: this.addListener,
       removeListener: this.removeListener,
       jumpTo: this.jumpTo,
-      render: children => (
+      render: (children) => (
         <Animated.ScrollView
           pagingEnabled
           directionalLockEnabled


### PR DESCRIPTION
Probably fixes https://github.com/react-native-community/react-native-tab-view/issues/1011 and is def an expected behavior or at least better than current