### PR TITLE
feat: add position prop and enhance stability of jumping through cards in ScrollPager

### DIFF
--- a/src/ScrollPager.tsx
+++ b/src/ScrollPager.tsx
@@ -197,7 +197,7 @@ export default class ScrollPager<T extends Route> extends React.Component<
           onScroll={this.onScroll}
           onScrollBeginDrag={handleSwipeStart}
           onScrollEndDrag={handleSwipeEnd}
-          //onMomentumScrollEnd={this.onScroll}
+          onMomentumScrollEnd={this.onScroll}
           contentOffset={this.initialOffset}
           style={styles.container}
           contentContainerStyle={

--- a/src/ScrollPager.tsx
+++ b/src/ScrollPager.tsx
@@ -130,7 +130,7 @@ export default class ScrollPager<T extends Route> extends React.Component<
     }
   };
 
-  private position = new Animated.Value(
+  private translateX = new Animated.Value(
     this.props.navigationState.index * this.props.layout.width
   );
 
@@ -138,7 +138,7 @@ export default class ScrollPager<T extends Route> extends React.Component<
     {
       nativeEvent: {
         contentOffset: {
-          x: this.position,
+          x: this.translateX,
         },
       },
     },
@@ -146,7 +146,7 @@ export default class ScrollPager<T extends Route> extends React.Component<
 
   private layoutWidthNode = new Value(this.props.layout.width);
 
-  private relativePosition = divide(this.position, this.layoutWidthNode);
+  private relativePosition = divide(this.translateX, this.layoutWidthNode);
 
   private prevRelPosition = new Animated.Value(0);
 
@@ -213,7 +213,7 @@ export default class ScrollPager<T extends Route> extends React.Component<
         >
           {children}
           <Animated.Code
-            exec={onChange(this.position, [
+            exec={onChange(this.translateX, [
               cond(
                 and(
                   eq(round(this.relativePosition), this.relativePosition),


### PR DESCRIPTION
1. From some reason, I observe that `position` on iOS is sometimes +/- 1.0 (exactly +1.0 or -1) and the source of this bug is inside RN scrollview when we call scrollTo.

2. In this PR I handle this case with 
```js
eq(
  modulo(sub(this.prevRelPosition, this.relativePosition), 1),
  0
)
```

if the condition is correct, we need to ignore this event

3. I need `position` prop (to animate the opacity of one tab)

4. Added this prop with similar case-checking like in 2.





Tested on both platform and observed no regressions