### PR TITLE
Fix: animated position and offset to be in sync with active page index

### DIFF
--- a/src/PagerViewAdapter.tsx
+++ b/src/PagerViewAdapter.tsx
@@ -142,6 +142,8 @@ export default function PagerViewAdapter<T extends Route>({
         onPageSelected={(e) => {
           const index = e.nativeEvent.position;
           indexRef.current = index;
+          position.setValue(index);
+          offset.setValue(0);
           onIndexChange(index);
         }}
         onPageScrollStateChanged={onPageScrollStateChanged}


### PR DESCRIPTION
**Motivation**
Animated value provided down within TabBarProps could become unsync with actual page index.
