### PR TITLE
Fix: the tab header not sync with scene swipe when header is long

### DIFF
--- a/src/TabBar.tsx
+++ b/src/TabBar.tsx
@@ -62,6 +62,7 @@ export type Props<T extends Route> = SceneRendererProps & {
   contentContainerStyle?: StyleProp<ViewStyle>;
   style?: StyleProp<ViewStyle>;
   gap?: number;
+  testID?: string;
 };
 
 type FlattenedTabWidth = string | number | undefined;
@@ -120,7 +121,7 @@ const getTranslateX = (
     I18nManager.isRTL ? 1 : -1
   );
 
-const getTabBarWidth = <T extends Route> ({
+const getTabBarWidth = <T extends Route>({
   navigationState,
   layout,
   gap,
@@ -149,7 +150,7 @@ const getTabBarWidth = <T extends Route> ({
   );
 };
 
-const normalizeScrollValue = <T extends Route> ({
+const normalizeScrollValue = <T extends Route>({
   layout,
   navigationState,
   gap,
@@ -182,7 +183,7 @@ const normalizeScrollValue = <T extends Route> ({
   return scrollValue;
 };
 
-const getScrollAmount = <T extends Route> ({
+const getScrollAmount = <T extends Route>({
   layout,
   navigationState,
   gap,
@@ -237,8 +238,8 @@ const getAccessibilityLabelDefault = ({ route }: Scene<Route>) =>
   typeof route.accessibilityLabel === 'string'
     ? route.accessibilityLabel
     : typeof route.title === 'string'
-      ? route.title
-      : undefined;
+    ? route.title
+    : undefined;
 
 const renderIndicatorDefault = (props: IndicatorProps<Route>) => (
   <TabBarIndicator {...props} />
@@ -246,7 +247,7 @@ const renderIndicatorDefault = (props: IndicatorProps<Route>) => (
 
 const getTestIdDefault = ({ route }: Scene<Route>) => route.testID;
 
-export default function TabBar<T extends Route> ({
+export default function TabBar<T extends Route>({
   getLabelText = getLabelTextDefault,
   getAccessible = getAccessibleDefault,
   getAccessibilityLabel = getAccessibilityLabelDefault,
@@ -281,7 +282,9 @@ export default function TabBar<T extends Route> ({
   const isFirst = React.useRef(true);
   const scrollAmount = useAnimatedValue(0);
   const measuredTabWidths = React.useRef<Record<string, number>>({});
-  const measureTabWidthsTimer = React.useRef<null | ReturnType<typeof setTimeout>>(null);
+  const measureTabWidthsTimer = React.useRef<null | ReturnType<
+    typeof setTimeout
+  >>(null);
 
   const { routes } = navigationState;
   const flattenedTabWidth = getFlattenedTabWidth(tabStyle);
@@ -295,7 +298,7 @@ export default function TabBar<T extends Route> ({
     flattenedTabWidth,
   });
 
-  const mesureRoutes = routes.slice(0, navigationState.index + 1)
+  const mesureRoutes = routes.slice(0, navigationState.index + 1);
   const hasMeasuredTabWidths =
     Boolean(layout.width) &&
     mesureRoutes.every((r) => typeof tabWidths[r.key] === 'number');
@@ -371,17 +374,17 @@ export default function TabBar<T extends Route> ({
         pressOpacity: pressOpacity,
         onLayout: isWidthDynamic
           ? (e: LayoutChangeEvent) => {
-            measuredTabWidths.current[route.key] = e.nativeEvent.layout.width;
+              measuredTabWidths.current[route.key] = e.nativeEvent.layout.width;
 
-            // When we have measured widths for all of the tabs, we should updates the state
-            // We avoid doing separate setState for each layout since it triggers multiple renders and slows down app
-            if (measureTabWidthsTimer.current) {
-              clearTimeout(measureTabWidthsTimer.current)
+              // When we have measured widths for all of the tabs, we should updates the state
+              // We avoid doing separate setState for each layout since it triggers multiple renders and slows down app
+              if (measureTabWidthsTimer.current) {
+                clearTimeout(measureTabWidthsTimer.current);
+              }
+              measureTabWidthsTimer.current = setTimeout(() => {
+                setTabWidths({ ...measuredTabWidths.current });
+              }, 300);
             }
-            measureTabWidthsTimer.current = setTimeout(() => {
-              setTabWidths({ ...measuredTabWidths.current });
-            }, 300)
-          }
           : undefined,
         onPress: () => {
           const event: Scene<T> & Event = {
@@ -406,13 +409,13 @@ export default function TabBar<T extends Route> ({
         // Calculate the deafult width for tab for FlatList to work
         defaultTabWidth: !isWidthDynamic
           ? getComputedTabWidth(
-            index,
-            layout,
-            routes,
-            scrollEnabled,
-            tabWidths,
-            getFlattenedTabWidth(tabStyle)
-          )
+              index,
+              layout,
+              routes,
+              scrollEnabled,
+              tabWidths,
+              getFlattenedTabWidth(tabStyle)
+            )
           : undefined,
       };
 
@@ -463,9 +466,9 @@ export default function TabBar<T extends Route> ({
       styles.tabContent,
       scrollEnabled
         ? {
-          width:
-            tabBarWidth > separatorsWidth ? tabBarWidth : tabBarWidthPercent,
-        }
+            width:
+              tabBarWidth > separatorsWidth ? tabBarWidth : tabBarWidthPercent,
+          }
         : styles.container,
       contentContainerStyle,
     ],
@@ -503,8 +506,8 @@ export default function TabBar<T extends Route> ({
           tabBarWidth > separatorsWidth
             ? { width: tabBarWidth - separatorsWidth }
             : scrollEnabled
-              ? { width: tabBarWidthPercent }
-              : null,
+            ? { width: tabBarWidthPercent }
+            : null,
           indicatorContainerStyle,
         ]}
       >

--- a/src/TabBar.tsx
+++ b/src/TabBar.tsx
@@ -275,6 +275,7 @@ export default function TabBar<T extends Route>({
   renderTabBarItem,
   style,
   tabStyle,
+  testID,
 }: Props<T>) {
   const [layout, setLayout] = React.useState<Layout>({ width: 0, height: 0 });
   const [tabWidths, setTabWidths] = React.useState<Record<string, number>>({});
@@ -552,6 +553,7 @@ export default function TabBar<T extends Route>({
           renderItem={renderItem}
           onScroll={handleScroll}
           ref={flatListRef}
+          testID={testID}
         />
       </View>
     </Animated.View>


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

**Motivation**

- The Tab Header is utilizing FlatList for rendering propose.
- FlatList will NOT try to render ALL of the content if the content is long for performant reasons.
- With the previous code, the tab header moves ONLY when all of the header content is rendered.
**These cause the header will not sync with the scene swipe when the header is long**

![output](https://user-images.githubusercontent.com/18628246/200739223-f0236602-ea31-47bc-99c2-5fb72f7c0801.gif)

**Test plan**

After the patch, the tab header can follow the screen swipe, with no performance drawback.
![output1](https://user-images.githubusercontent.com/18628246/200740018-9a725b7a-5f95-4d9a-adfb-c8d274e273c0.gif)

**Code formatting**

Look around. Match the style of the rest of the codebase. Run `yarn lint --fix` before committing.
